### PR TITLE
version 1.1.2 - fixes

### DIFF
--- a/__tests__/date_time.test.js
+++ b/__tests__/date_time.test.js
@@ -2437,7 +2437,7 @@ describe('DateTime', () => {
             expect(m instanceof moment).toBe(true);
             expect(m instanceof DateTime).toBe(false);
             expect(DateTime.isDateTime(m)).toBe(false);
-            expect(m.toISOString(true)).toEqual(dateTime.toISOString(false));
+            expect(m.toISOString(true).replace('+00:00', 'Z')).toEqual(dateTime.toISOString(false));
         });
 
         it('should allow to construct a new JS Date object directly', () => {

--- a/__tests__/date_time.test.js
+++ b/__tests__/date_time.test.js
@@ -2,7 +2,7 @@ const moment = require('moment-timezone');
 
 const {DateOnly} = require('../date-only.cjs');
 const {DateTime} = require('../date-time.cjs');
-const {toDateOnly, toDateTime, isDateValid} = require('../index.cjs');
+const {toDateOnly, toDateTime, isDateValid, formatToDateOnly} = require('../index.cjs');
 const {getLocalTimezone} = require('../utils/tz.cjs');
 
 const DEFAULT_LOCALE = moment().locale();
@@ -841,8 +841,10 @@ describe('DateTime', () => {
                 const result = [
                     DateTime.fromDateTime(DateTime.invalid()),
                     DateTime.fromDateTime(DateTime.invalid(), CUSTOM_LOCALE),
+                    DateTime.fromDateTime(false),
+                    DateTime.fromDateTime(NaN, CUSTOM_LOCALE),
                 ];
-                expect(result.map(isDateValid)).toEqual([false, false]);
+                expect(result.map(isDateValid)).toEqual(result.map(() => false));
             });
 
             it('should handle weird DateTime object', () => {
@@ -868,6 +870,62 @@ describe('DateTime', () => {
                 expect(result.toJSON()).toBe('2020-02-01T00:00:00.000Z');
                 expect(result.locale).toEqual(DEFAULT_LOCALE);
                 expect(result.timezone).toBe('UTC');
+            });
+
+            it('should construct from a string', () => {
+                const cases = [
+                    '2000-01-03',
+                    '2000-02-04T22:33:44',
+                    '2000-03-05T22:33:44.222',
+                    '2000-04-06T22:33:44Z',
+                    '2000-05-07T22:33:44.222Z',
+                    '2000-06-08T22:33:44+03:00',
+                    '2000-07-09T22:33:44.222+03:00',
+                ];
+                const expectedStringValueByCase = {
+                    '2000-01-03': '2000-01-03T00:00:00.000Z',
+                    '2000-02-04T22:33:44': '2000-02-04T22:33:44.000Z',
+                    '2000-03-05T22:33:44.222': '2000-03-05T22:33:44.222Z',
+                    '2000-04-06T22:33:44Z': '2000-04-06T22:33:44.000Z',
+                    '2000-05-07T22:33:44.222Z': '2000-05-07T22:33:44.222Z',
+                    '2000-06-08T22:33:44+03:00': '2000-06-08T19:33:44.000Z',
+                    '2000-07-09T22:33:44.222+03:00': '2000-07-09T19:33:44.222Z',
+                };
+                const getExpectedStringValue = (s) => expectedStringValueByCase[s];
+
+                for (const stringValue of cases) {
+                    let result = DateTime.fromDateTime(stringValue);
+                    expect(result).toBeDefined();
+                    expect(result.isDateTime).toBe(true);
+                    expect(result.toISOString(true)).toEqual(getExpectedStringValue(stringValue));
+                    expect(result.locale).toBe(DEFAULT_LOCALE);
+
+                    result = DateTime.fromDateTime(stringValue, CUSTOM_LOCALE);
+                    expect(result).toBeDefined();
+                    expect(result.isDateTime).toBe(true);
+                    expect(result.toISOString(true)).toEqual(getExpectedStringValue(stringValue));
+                    expect(result.locale).toBe(CUSTOM_LOCALE);
+                }
+            });
+
+            it('should handle a numeric timestamp', () => {
+                const dateValue = new Date(2020, 1, 1, 2, 13);
+                const result = DateTime.fromDateTime(dateValue.getTime());
+                expect(result).toBeInstanceOf(DateTime);
+                expect(result.isDateTime).toBe(true);
+                expect(result.toObject()).toEqual({
+                    year: 2020,
+                    month: 2,
+                    day: 1,
+                    hour: 2,
+                    minute: 13,
+                    second: 0,
+                    millisecond: 0,
+                    offset: DEFAULT_TZ_OFFSET,
+                    timezone: DEFAULT_TZ,
+                });
+                expect(result.locale).toEqual(DEFAULT_LOCALE);
+                expect(result.timezone).toBe(DEFAULT_TZ);
             });
 
             it('should thrown on unexpected DateTime object', () => {
@@ -1015,6 +1073,33 @@ describe('DateTime', () => {
                 expect(result.toJSON()).toBe('2020-02-01T00:00:00.000Z');
                 expect(result.locale).toEqual(DEFAULT_LOCALE);
                 expect(result.timezone).toBe('UTC');
+            });
+
+            it('should construct from a string', () => {
+                const cases = [
+                    '2000-01-03',
+                    '2000-02-04T22:33:44',
+                    '2000-03-05T22:33:44.222',
+                    '2000-04-06T22:33:44Z',
+                    '2000-05-07T22:33:44.222Z',
+                    '2000-06-08T22:33:44+03:00',
+                    '2000-07-09T10:33:44.222+03:00',
+                ];
+                const getExpectedStringValue = (s) => formatToDateOnly(s, {includeTimeAndZone: true});
+
+                for (const stringValue of cases) {
+                    let result = DateTime.fromDateOnly(stringValue);
+                    expect(result).toBeDefined();
+                    expect(result.isDateTime).toBe(true);
+                    expect(result.toISOString(true)).toEqual(getExpectedStringValue(stringValue));
+                    expect(result.locale).toBe(DEFAULT_LOCALE);
+
+                    result = DateTime.fromDateOnly(stringValue, CUSTOM_LOCALE);
+                    expect(result).toBeDefined();
+                    expect(result.isDateTime).toBe(true);
+                    expect(result.toISOString(true)).toEqual(getExpectedStringValue(stringValue));
+                    expect(result.locale).toBe(CUSTOM_LOCALE);
+                }
             });
         });
 
@@ -1620,6 +1705,8 @@ describe('DateTime', () => {
                     DateTime.fromAnyDate(undefined, CUSTOM_LOCALE),
                     DateTime.fromAnyDate(NaN),
                     DateTime.fromAnyDate(NaN, CUSTOM_LOCALE),
+                    DateTime.fromAnyDate({}),
+                    DateTime.fromAnyDate({}, CUSTOM_LOCALE),
                 ];
                 expect(result.map(isDateValid)).toEqual(result.map(() => false));
             });
@@ -2343,28 +2430,24 @@ describe('DateTime', () => {
 
     describe('compatibility', () => {
         it('should allow to construct a new moment object directly', () => {
-            const dateOnly = DateOnly.now();
-            expect(dateOnly).toBeInstanceOf(DateOnly);
-            const m = moment(dateOnly);
+            const dateTime = DateTime.now();
+            expect(dateTime).toBeInstanceOf(DateTime);
+            const m = moment(dateTime);
             expect(moment.isMoment(m)).toBe(true);
             expect(m instanceof moment).toBe(true);
-            expect(m instanceof DateOnly).toBe(false);
-            expect(DateOnly.isDateOnly(m)).toBe(false);
-            expect(m.format('YYYY-MM-DD')).toEqual(dateOnly.toJSON());
-            expect({year: m.year(), month: m.month() + 1, day: m.date()}).toEqual(dateOnly.toObject());
+            expect(m instanceof DateTime).toBe(false);
+            expect(DateTime.isDateTime(m)).toBe(false);
+            expect(m.toISOString(true)).toEqual(dateTime.toISOString(false));
         });
 
         it('should allow to construct a new JS Date object directly', () => {
-            const dateOnly = DateOnly.now();
-            expect(dateOnly).toBeInstanceOf(DateOnly);
-            const jsDate = new Date(dateOnly);
+            const dateTime = DateTime.now();
+            expect(dateTime).toBeInstanceOf(DateTime);
+            const jsDate = new Date(dateTime);
             expect(jsDate instanceof Date).toBe(true);
-            expect(jsDate instanceof DateOnly).toBe(false);
-            expect(DateOnly.isDateOnly(jsDate)).toBe(false);
-            expect(jsDate.toISOString()).toEqual(dateOnly.toISOString());
-            expect({year: jsDate.getFullYear(), month: jsDate.getMonth() + 1, day: jsDate.getDate()}).toEqual(
-                dateOnly.toObject()
-            );
+            expect(jsDate instanceof DateTime).toBe(false);
+            expect(DateTime.isDateTime(jsDate)).toBe(false);
+            expect(jsDate.toISOString()).toEqual(dateTime.toISOString(true));
         });
     });
 });

--- a/__tests__/plugins/joi.test.js
+++ b/__tests__/plugins/joi.test.js
@@ -2,7 +2,7 @@ const JoiModule = require('joi');
 
 const {DateOnly} = require('../../date-only.cjs');
 const {DateTime} = require('../../date-time.cjs');
-const {formatToDateOnly, toDateTime} = require('../../index.cjs');
+const {formatToDateOnly, toDateTime, toDateOnly} = require('../../index.cjs');
 const {anyDate, dateOnly, dateTime} = require('../../plugins/joi.cjs');
 
 describe('Joi Date Extensions', () => {
@@ -14,7 +14,7 @@ describe('Joi Date Extensions', () => {
     };
 
     describe('anyDate', () => {
-        const schema = joi.anyDate();
+        const schema = joi.anyDate().allow(null);
 
         it.each([
             '2023-01-01',
@@ -29,6 +29,12 @@ describe('Joi Date Extensions', () => {
             expect(formatToDateOnly(result.value)).toEqual(formatToDateOnly(value));
         });
 
+        it.each([null, undefined])('should accept "%s"', (value) => {
+            const result = validate(schema, value);
+            expect(result.isValid).toBe(true);
+            expect(result.value).toEqual(value);
+        });
+
         it.each(['01/01/2000', '2000/01/01', '99-02-15', '2023-01-01 00:00:00', '2023-01-01 00:00:00', 1425215164236])(
             'should reject "%s"',
             (value) => {
@@ -38,13 +44,19 @@ describe('Joi Date Extensions', () => {
     });
 
     describe('dateOnly', () => {
-        const schema = joi.dateOnly();
+        const schema = joi.dateOnly().allow(null);
 
         it.each(['2023-01-01', '1990-10-12'])('should accept "%s"', (value) => {
             const result = validate(schema, value);
             expect(result.isValid).toBe(true);
             expect(result.value).toBeInstanceOf(DateOnly);
             expect(formatToDateOnly(result.value)).toEqual(value);
+        });
+
+        it.each([null, undefined])('should accept "%s"', (value) => {
+            const result = validate(schema, value);
+            expect(result.isValid).toBe(true);
+            expect(result.value).toEqual(value);
         });
 
         it.each([
@@ -63,7 +75,7 @@ describe('Joi Date Extensions', () => {
     });
 
     describe('dateTime', () => {
-        const schema = joi.dateTime();
+        const schema = joi.dateTime().allow(null);
 
         it.each([
             '2023-01-01T00:00:00Z',
@@ -76,6 +88,12 @@ describe('Joi Date Extensions', () => {
             expect(result.isValid).toBe(true);
             expect(result.value).toBeInstanceOf(DateTime);
             expect(result.value.valueOf()).toEqual(toDateTime(value).valueOf());
+        });
+
+        it.each([null, undefined])('should accept "%s"', (value) => {
+            const result = validate(schema, value);
+            expect(result.isValid).toBe(true);
+            expect(result.value).toEqual(value);
         });
 
         it.each([

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -155,6 +155,21 @@ class DateTime {
         return new DateTime(moment(NaN));
     }
 
+    static _fromString(dateString, locale) {
+        if (DATE_ONLY_REGEX.test(dateString)) {
+            return this.fromDateOnly(dateString, locale);
+        } else if (TIME_WITHOUT_ZONE_REGEX.test(dateString)) {
+            return this.fromMomentDate(moment.tz(dateString, 'UTC'), locale);
+        } else if (DATE_TIME_REGEX.test(dateString)) {
+            const offset = extractTimezoneOffset(dateString);
+            const momentDate = moment(dateString).utcOffset(offset === 'Z' ? '+00:00' : offset);
+            return this.fromMomentDate(momentDate, locale);
+        }
+        const dateValue = new Date(dateString);
+        if (isNaN(dateValue)) return this.invalid();
+        return new DateTime(moment(dateValue), locale);
+    }
+
     /**
      * Construct a new date-time from a moment object value
      * @param {Moment} date any moment date
@@ -182,25 +197,28 @@ class DateTime {
         if (dateTime instanceof DateTime) {
             return new DateTime(dateTime._innerDate, locale);
         } else if (typeof dateTime === 'string') {
-            return new DateTime(moment(dateTime), locale);
-        } else if (typeof dateTime === 'object') {
-            const month = __getObjectValue(dateTime.month);
-            const obj = {
-                year: __getObjectValue(dateTime.year),
-                month: month ? month - 1 : undefined,
-                date: __getObjectValue(dateTime.day) || __getObjectValue(dateTime.date),
-                hour: __getObjectValue(dateTime.hour) || __getObjectValue(dateTime.hours),
-                minute: __getObjectValue(dateTime.minute) || __getObjectValue(dateTime.minutes),
-                second: __getObjectValue(dateTime.second) || __getObjectValue(dateTime.seconds),
-                millisecond: __getObjectValue(dateTime.millisecond) || __getObjectValue(dateTime.milliseconds),
-            };
-            const tz = __getObjectValue(dateTime.timezone) || __getObjectValue(dateTime.tz);
-            if (tz) return new DateTime(moment.tz(obj, tz), locale);
-            const offset = __getObjectValue(dateTime.offset);
-            if (offset) return new DateTime(moment(obj).utcOffset(offset, true), locale);
-            return new DateTime(moment(obj), locale);
+            return DateTime._fromString(dateTime, locale);
+        } else if (typeof dateTime === 'number') {
+            return DateTime.fromJsDate(new Date(dateTime));
+        } else if (typeof dateTime !== 'object') {
+            return DateTime.invalid();
         }
-        return new DateTime(moment(String(dateTime)), locale);
+        
+        const month = __getObjectValue(dateTime.month);
+        const obj = {
+            year: __getObjectValue(dateTime.year),
+            month: month ? month - 1 : undefined,
+            date: __getObjectValue(dateTime.day) || __getObjectValue(dateTime.date),
+            hour: __getObjectValue(dateTime.hour) || __getObjectValue(dateTime.hours),
+            minute: __getObjectValue(dateTime.minute) || __getObjectValue(dateTime.minutes),
+            second: __getObjectValue(dateTime.second) || __getObjectValue(dateTime.seconds),
+            millisecond: __getObjectValue(dateTime.millisecond) || __getObjectValue(dateTime.milliseconds),
+        };
+        const tz = __getObjectValue(dateTime.timezone) || __getObjectValue(dateTime.tz);
+        if (tz) return new DateTime(moment.tz(obj, tz), locale);
+        const offset = __getObjectValue(dateTime.offset);
+        if (offset) return new DateTime(moment(obj).utcOffset(offset, true), locale);
+        return new DateTime(moment(obj), locale);
     }
 
     /**
@@ -220,7 +238,7 @@ class DateTime {
                 locale
             );
         }
-        return new DateTime(moment.tz(String(dateOnly), 'UTC'), locale || dateOnly.locale);
+        return new DateTime(moment.tz(String(dateOnly), 'UTC').startOf('day'), locale || dateOnly.locale);
     }
 
     /**
@@ -235,16 +253,7 @@ class DateTime {
         else if (moment.isMoment(anyDate)) return this.fromMomentDate(anyDate, locale);
         else if (anyDate instanceof Date) return this.fromJsDate(anyDate, locale);
         else if (typeof anyDate === 'number') return this.fromJsDate(new Date(anyDate), locale);
-        else if (typeof anyDate === 'string') {
-            if (DATE_ONLY_REGEX.test(anyDate)) return this.fromDateOnly(anyDate, locale);
-            else if (TIME_WITHOUT_ZONE_REGEX.test(anyDate))
-                return this.fromMomentDate(moment.tz(anyDate, 'UTC'), locale);
-            else if (DATE_TIME_REGEX.test(anyDate)) {
-                const offset = extractTimezoneOffset(anyDate);
-                const momentDate = moment(anyDate).utcOffset(offset === 'Z' ? '+00:00' : offset);
-                return this.fromMomentDate(momentDate, locale);
-            }
-        }
+        else if (typeof anyDate === 'string') return this._fromString(anyDate, locale);
         return this.fromJsDate(new Date(new String(anyDate)), locale);
     }
 
@@ -270,10 +279,6 @@ class DateTime {
      */
     constructor(date, locale) {
         this._innerDate = locale ? moment(date).locale(locale) : moment(date);
-    }
-
-    get [Symbol.toStringTag]() {
-        return 'Date';
     }
 
     get isDateTime() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",
@@ -53,13 +53,9 @@
     },
     "devDependencies": {
         "jest": "^29.7.0",
-        "joi": "^17.12.0",
-        "sequelize": "^6.37.1",
+        "joi": "17.x",
+        "sequelize": "6.x",
         "sqlite3": "^5.1.7"
-    },
-    "peerDependencies": {
-        "joi": "^17.x",
-        "sequelize": "^6.25"
     },
     "dependencies": {
         "moment-timezone": "^0.5.45"

--- a/plugins/joi.d.mts
+++ b/plugins/joi.d.mts
@@ -5,17 +5,92 @@ import {Extension, Root} from 'joi';
  * Accepts either a date-only or a date-time value.
  * Strings must be correctly formatted.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {anyDate} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(anyDate);
+ * 
+ * const schema = joi.object().keys({date: joi.anyDate()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '2020-07-19 00:00:00.000Z'});
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * 
+ * // These are not
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function anyDate(joi: Root): Extension;
+
 /**
  * Generates a schema object that matches a string data type or date-only data type.
  * Strings must be correctly formatted as YYYY-MM-DD.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {dateOnly} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(dateOnly);
+ * 
+ * const schema = joi.object().keys({date: joi.dateOnly()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '1990-01-11'});
+ * 
+ * // These are not
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function dateOnly(joi: Root): Extension;
+
 /**
  * Generates a schema object that matches a string data type or date-time data type.
  * Strings must be correctly formatted as an ISO date.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {dateTime} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(dateTime);
+ * 
+ * const schema = joi.object().keys({date: joi.dateTime()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19 00:00:00.000Z'});
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * 
+ * // These are not
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '1990-01-11'});
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function dateTime(joi: Root): Extension;

--- a/plugins/joi.d.ts
+++ b/plugins/joi.d.ts
@@ -5,17 +5,92 @@ import {Extension, Root} from 'joi';
  * Accepts either a date-only or a date-time value.
  * Strings must be correctly formatted.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {anyDate} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(anyDate);
+ * 
+ * const schema = joi.object().keys({date: joi.anyDate()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '2020-07-19 00:00:00.000Z'});
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * 
+ * // These are not
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function anyDate(joi: Root): Extension;
+
 /**
  * Generates a schema object that matches a string data type or date-only data type.
  * Strings must be correctly formatted as YYYY-MM-DD.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {dateOnly} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(dateOnly);
+ * 
+ * const schema = joi.object().keys({date: joi.dateOnly()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '1990-01-11'});
+ * 
+ * // These are not
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function dateOnly(joi: Root): Extension;
+
 /**
  * Generates a schema object that matches a string data type or date-time data type.
  * Strings must be correctly formatted as an ISO date.
  * All values must be valid.
+ * @example
+ * ````javascript
+ * const {dateTime} = require('vintage-time/plugins/joi');
+ * joi = joi.extend(dateTime);
+ * 
+ * const schema = joi.object().keys({date: joi.dateTime()});
+ * // These are valid strings
+ * schema.validate({date: '2020-07-19 00:00:00.000Z'});
+ * schema.validate({date: '2020-07-19 00:00:00Z'});
+ * schema.validate({date: '2020-07-19 00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19 01:20:03'});
+ * schema.validate({date: '2020-07-19 01:20:03.657Z'});
+ * schema.validate({date: '2020-07-19T00:00:00Z'});
+ * schema.validate({date: '2020-07-19T00:00:00-03:00'});
+ * schema.validate({date: '2020-07-19T01:20:03'});
+ * schema.validate({date: '2020-07-19T01:20:03.657Z'});
+ * 
+ * // These are not
+ * schema.validate({date: '2020-07-19'});
+ * schema.validate({date: '1990-01-11'});
+ * schema.validate({date: '07/19/2020'});
+ * schema.validate({date: '2020/07/19'});
+ * schema.validate({date: '01:20:03.657Z'});
+ * schema.validate({date: '2020/07/19 at 3:00 PM'});
+ * ````
  */
 export function dateTime(joi: Root): Extension;

--- a/plugins/sequelize.d.mts
+++ b/plugins/sequelize.d.mts
@@ -9,6 +9,23 @@ import {DateTime, DateOnly} from '../index.mts';
  * @param propertyName the property name
  * @param strict defines whether or not to throw when the value is not an instance of DateOnly. Defaults to false
  * @returns the necessary sequelize configuration for the property to work with DATEONLY
+ * @example
+ * ````javascript
+ * const {dateOnlyColumn} = require('vintage-time/plugins/sequelize');
+ * const model = sequelize.define('DateDummy', {
+ *         startDate: {
+ *             ...dateOnlyColumn('startDate'),
+ *             allowNull: true,
+ *         },
+ *     },
+ *     {tableName: 'dummies'}
+ * );
+ * 
+ * // ...
+ * 
+ * const entry = model.findOne();
+ * console.log(entry.startDate instanceof DateOnly); // true
+ * ````
  */
 export function dateOnlyColumn(propertyName: string, strict?: boolean): {
     type: typeof DataTypes.DATEONLY,
@@ -21,6 +38,24 @@ export function dateOnlyColumn(propertyName: string, strict?: boolean): {
  * @param propertyName the property name
  * @param strict defines whether or not to throw when the value is not an instance of DateTime. Defaults to false
  * @returns the necessary sequelize configuration for the property to work with DATEONLY
+ * @example
+ * ````javascript
+ * const {dateTimeColumn} = require('vintage-time/plugins/sequelize');
+ * const model = sequelize.define('DateDummy', {
+ *         archivedAt: {
+ *             ...dateTimeColumn('archivedAt'),
+ *             allowNull: false,
+ *             defaultValue: () => toDateTime.now(),
+ *         },
+ *     },
+ *     {tableName: 'dummies'}
+ * );
+ * 
+ * // ...
+ * 
+ * const entry = model.findOne();
+ * console.log(entry.archivedAt instanceof DateTime); // true
+ * ````
  */
 export function dateTimeColumn(propertyName: string, strict?: boolean): {
     type: typeof DataTypes.DATE,

--- a/plugins/sequelize.d.ts
+++ b/plugins/sequelize.d.ts
@@ -9,6 +9,23 @@ import {DateTime, DateOnly} from '../index.cts';
  * @param propertyName the property name
  * @param strict defines whether or not to throw when the value is not an instance of DateOnly. Defaults to false
  * @returns the necessary sequelize configuration for the property to work with DATEONLY
+ * @example
+ * ````javascript
+ * const {dateOnlyColumn} = require('vintage-time/plugins/sequelize');
+ * const model = sequelize.define('DateDummy', {
+ *         startDate: {
+ *             ...dateOnlyColumn('startDate'),
+ *             allowNull: true,
+ *         },
+ *     },
+ *     {tableName: 'dummies'}
+ * );
+ * 
+ * // ...
+ * 
+ * const entry = model.findOne();
+ * console.log(entry.startDate instanceof DateOnly); // true
+ * ````
  */
 export function dateOnlyColumn(propertyName: string, strict?: boolean): {
     type: typeof DataTypes.DATEONLY,
@@ -21,6 +38,24 @@ export function dateOnlyColumn(propertyName: string, strict?: boolean): {
  * @param propertyName the property name
  * @param strict defines whether or not to throw when the value is not an instance of DateTime. Defaults to false
  * @returns the necessary sequelize configuration for the property to work with DATEONLY
+ * @example
+ * ````javascript
+ * const {dateTimeColumn} = require('vintage-time/plugins/sequelize');
+ * const model = sequelize.define('DateDummy', {
+ *         archivedAt: {
+ *             ...dateTimeColumn('archivedAt'),
+ *             allowNull: false,
+ *             defaultValue: () => toDateTime.now(),
+ *         },
+ *     },
+ *     {tableName: 'dummies'}
+ * );
+ * 
+ * // ...
+ * 
+ * const entry = model.findOne();
+ * console.log(entry.archivedAt instanceof DateTime); // true
+ * ````
  */
 export function dateTimeColumn(propertyName: string, strict?: boolean): {
     type: typeof DataTypes.DATE,


### PR DESCRIPTION
* Improved the documentation a little more
* Added examples to the plugins
* Fixed DateTime.fromDateTime to better handle strings and other edge cases