### PR TITLE
version 1.2.2 - fix import isMoment

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,4 +1,4 @@
-const {isMoment} = require('moment-timezone');
+const moment = require('moment-timezone');
 
 const {DateOnly} = require('./date-only.cjs');
 const {DateTime} = require('./date-time.cjs');
@@ -18,7 +18,7 @@ const {LOCALE_FORMATS} = require('./locale-formats.cjs');
 function getDateLocale(anyDate) {
     if (!anyDate) return undefined;
     else if (anyDate instanceof Date) return undefined;
-    else if (isMoment(anyDate)) return anyDate.locale();
+    else if (moment.isMoment(anyDate)) return anyDate.locale();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.locale;
     return undefined;
 }
@@ -31,7 +31,7 @@ function getDateLocale(anyDate) {
 function isDateValid(anyDate) {
     if (!anyDate) return false;
     else if (anyDate instanceof Date) return !isNaN(anyDate);
-    else if (isMoment(anyDate)) return anyDate.isValid();
+    else if (moment.isMoment(anyDate)) return anyDate.isValid();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.isValid;
     return toDateTime(anyDate).isValid;
 }
@@ -44,7 +44,7 @@ function isDateValid(anyDate) {
 function toJsDate(anyDate) {
     if (!anyDate) return undefined;
     else if (anyDate instanceof Date) return anyDate;
-    else if (isMoment(anyDate)) return anyDate.toDate();
+    else if (moment.isMoment(anyDate)) return anyDate.toDate();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.toJsDate();
     return toDateTime(anyDate).toJsDate();
 }

--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,4 @@
-import {isMoment} from 'moment-timezone';
+import moment from 'moment-timezone';
 
 import {DateOnly} from './date-only.mjs';
 import {DateTime} from './date-time.mjs';
@@ -21,7 +21,7 @@ export {DateTime} from './date-time.mjs';
 export function getDateLocale(anyDate) {
     if (!anyDate) return undefined;
     else if (anyDate instanceof Date) return undefined;
-    else if (isMoment(anyDate)) return anyDate.locale();
+    else if (moment.isMoment(anyDate)) return anyDate.locale();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.locale;
     return undefined;
 }
@@ -34,7 +34,7 @@ export function getDateLocale(anyDate) {
 export function isDateValid(anyDate) {
     if (!anyDate) return false;
     else if (anyDate instanceof Date) return !isNaN(anyDate);
-    else if (isMoment(anyDate)) return anyDate.isValid();
+    else if (moment.isMoment(anyDate)) return anyDate.isValid();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.isValid;
     return toDateTime(anyDate).isValid;
 }
@@ -47,7 +47,7 @@ export function isDateValid(anyDate) {
 export function toJsDate(anyDate) {
     if (!anyDate) return undefined;
     else if (anyDate instanceof Date) return anyDate;
-    else if (isMoment(anyDate)) return anyDate.toDate();
+    else if (moment.isMoment(anyDate)) return anyDate.toDate();
     else if (DateTime.isDateTime(anyDate) || DateOnly.isDateOnly(anyDate)) return anyDate.toJsDate();
     return toDateTime(anyDate).toJsDate();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",


### PR DESCRIPTION
Fix `isMoment is not exported by require('moment-timezone')`