### PR TITLE
version 1.2.3 - sequelize compatibility

### DIFF
--- a/date-only.cjs
+++ b/date-only.cjs
@@ -760,6 +760,21 @@ class DateOnly {
     getTime() {
         return this.toTimestamp();
     }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    replace(regex, replacement) {
+        return this.toJSON().replace(regex, replacement);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    startsWith(value) {
+        return this.toJSON().startsWith(value);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    endsWith(value) {
+        return this.toJSON().endsWith(value);
+    }
 }
 
 module.exports = {DateOnly};

--- a/date-only.mjs
+++ b/date-only.mjs
@@ -769,4 +769,19 @@ export class DateOnly {
     getTime() {
         return this.toTimestamp();
     }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    replace(regex, replacement) {
+        return this.toJSON().replace(regex, replacement);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    startsWith(value) {
+        return this.toJSON().startsWith(value);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    endsWith(value) {
+        return this.toJSON().endsWith(value);
+    }
 }

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -813,6 +813,21 @@ class DateTime {
     getTime() {
         return this.toTimestamp();
     }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    replace(regex, replacement) {
+        return this.toJSON().replace(regex, replacement);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    startsWith(value) {
+        return this.toJSON().startsWith(value);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    endsWith(value) {
+        return this.toJSON().endsWith(value);
+    }
 }
 
 module.exports = {DateTime};

--- a/date-time.mjs
+++ b/date-time.mjs
@@ -813,4 +813,19 @@ export class DateTime {
     getTime() {
         return this.toTimestamp();
     }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    replace(regex, replacement) {
+        return this.toJSON().replace(regex, replacement);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    startsWith(value) {
+        return this.toJSON().startsWith(value);
+    }
+
+    /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */
+    endsWith(value) {
+        return this.toJSON().endsWith(value);
+    }
 }

--- a/locale-formats.d.mts
+++ b/locale-formats.d.mts
@@ -19,4 +19,4 @@ export enum LOCALE_FORMATS {
     VERBAL_DATE_TIME_WEEKDAY_SHORT = 'llll',
     /** example for English `Thursday, September 4, 1986 8:30 PM` */
     VERBAL_DATE_TIME_WEEKDAY_LONG = 'LLLL',
-};
+}

--- a/locale-formats.d.ts
+++ b/locale-formats.d.ts
@@ -19,4 +19,4 @@ export enum LOCALE_FORMATS {
     VERBAL_DATE_TIME_WEEKDAY_SHORT = 'llll',
     /** example for English `Thursday, September 4, 1986 8:30 PM` */
     VERBAL_DATE_TIME_WEEKDAY_LONG = 'LLLL',
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",

--- a/plugins/sequelize.cjs
+++ b/plugins/sequelize.cjs
@@ -1,17 +1,28 @@
 const {DataTypes} = require('sequelize');
+const {SequelizeMethod} = require('sequelize/lib/utils');
 
 const {DateOnly} = require('../date-only.cjs');
 const {DateTime} = require('../date-time.cjs');
+
+/** @returns {value is SequelizeMethod} */
+function isSequelizeMethod(value) {
+    return value instanceof SequelizeMethod;
+}
 
 function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
     return {
         get() {
             const value = this.getDataValue(propertyName);
-            if (!value) return null;
+
+            if (isSequelizeMethod(value)) return value;
+            else if (!value) return null;
+
             return DateOnly.fromAnyDate(value);
         },
         set(value) {
-            if (value === null || value === undefined) {
+            if (isSequelizeMethod(value)) {
+                return;
+            } else if (value === null || value === undefined) {
                 this.setDataValue(propertyName, null);
                 return;
             }
@@ -49,11 +60,16 @@ function dateTimeColumnGetterSetter(propertyName, throwOnIncompatibleType) {
     return {
         get() {
             const value = this.getDataValue(propertyName);
-            if (!value) return null;
+            
+            if (isSequelizeMethod(value)) return value;
+            else if (!value) return null;
+
             return DateTime.fromAnyDate(value);
         },
         set(value) {
-            if (value === null || value === undefined) {
+            if (isSequelizeMethod(value)) {
+                return;
+            } else if (value === null || value === undefined) {
                 this.setDataValue(propertyName, null);
                 return;
             }

--- a/plugins/sequelize.mjs
+++ b/plugins/sequelize.mjs
@@ -1,17 +1,28 @@
 import {DataTypes} from 'sequelize';
+import {SequelizeMethod} from 'sequelize/lib/utils';
 
 import {DateOnly} from '../date-only.mjs';
 import {DateTime} from '../date-time.mjs';
+
+/** @returns {value is SequelizeMethod} */
+function isSequelizeMethod(value) {
+    return value instanceof SequelizeMethod;
+}
 
 function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
     return {
         get() {
             const value = this.getDataValue(propertyName);
-            if (!value) return null;
+
+            if (isSequelizeMethod(value)) return value;
+            else if (!value) return null;
+
             return DateOnly.fromAnyDate(value);
         },
         set(value) {
-            if (value === null || value === undefined) {
+            if (isSequelizeMethod(value)) {
+                return;
+            } else if (value === null || value === undefined) {
                 this.setDataValue(propertyName, null);
                 return;
             }
@@ -49,11 +60,16 @@ function dateTimeColumnGetterSetter(propertyName, throwOnIncompatibleType) {
     return {
         get() {
             const value = this.getDataValue(propertyName);
-            if (!value) return null;
+            
+            if (isSequelizeMethod(value)) return value;
+            else if (!value) return null;
+
             return DateTime.fromAnyDate(value);
         },
         set(value) {
-            if (value === null || value === undefined) {
+            if (isSequelizeMethod(value)) {
+                return;
+            } else if (value === null || value === undefined) {
                 this.setDataValue(propertyName, null);
                 return;
             }


### PR DESCRIPTION
* Fix locale-format type declaration files. Removed trailing semicolon.
* Added more methods for sequelize compatibility: replace, startsWith
* Handling sequelize literals and methods when getting or setting