### PR TITLE
version 1.3.1 - sequelize jest compatibility

### DIFF
--- a/__tests__/date_only.test.js
+++ b/__tests__/date_only.test.js
@@ -1670,18 +1670,6 @@ describe('DateOnly', () => {
     });
 
     describe('compatibility', () => {
-        it('should allow to construct a new moment object directly', () => {
-            const dateOnly = DateOnly.now();
-            expect(dateOnly).toBeInstanceOf(DateOnly);
-            const m = moment(dateOnly);
-            expect(moment.isMoment(m)).toBe(true);
-            expect(m instanceof moment).toBe(true);
-            expect(m instanceof DateOnly).toBe(false);
-            expect(DateOnly.isDateOnly(m)).toBe(false);
-            expect(m.format('YYYY-MM-DD')).toEqual(dateOnly.toJSON());
-            expect({year: m.year(), month: m.month() + 1, day: m.date()}).toEqual(dateOnly.toObject());
-        });
-
         it('should allow to construct a new JS Date object directly', () => {
             const dateOnly = DateOnly.now();
             expect(dateOnly).toBeInstanceOf(DateOnly);
@@ -1703,6 +1691,15 @@ describe('DateOnly', () => {
             expect(dateOnly.startsWith(dateString[0])).toBe(true);
             expect(dateOnly.endsWith(dateString)).toBe(true);
             expect(dateOnly.endsWith(dateString.at(-1))).toBe(true);
+        });
+
+        it('should be correctly asserted using expect.toMatchObject', () => {
+            const dateOnly = DateOnly.now().set({year: 2001});
+            const dateString = dateOnly.toJSON();
+            expect({dateOnly, dateString}).toMatchObject({
+                dateOnly: dateOnly.clone(),
+                dateString,
+            });
         });
     });
 });

--- a/__tests__/date_time.test.js
+++ b/__tests__/date_time.test.js
@@ -2760,17 +2760,6 @@ describe('DateTime', () => {
     });
 
     describe('compatibility', () => {
-        it('should allow to construct a new moment object directly', () => {
-            const dateTime = DateTime.now();
-            expect(dateTime).toBeInstanceOf(DateTime);
-            const m = moment(dateTime);
-            expect(moment.isMoment(m)).toBe(true);
-            expect(m instanceof moment).toBe(true);
-            expect(m instanceof DateTime).toBe(false);
-            expect(DateTime.isDateTime(m)).toBe(false);
-            expect(m.toISOString(true).replace('+00:00', 'Z')).toEqual(dateTime.toISOString(false));
-        });
-
         it('should allow to construct a new JS Date object directly', () => {
             const dateTime = DateTime.now();
             expect(dateTime).toBeInstanceOf(DateTime);
@@ -2789,6 +2778,15 @@ describe('DateTime', () => {
             expect(dateTime.startsWith(dateString[0])).toBe(true);
             expect(dateTime.endsWith(dateString)).toBe(true);
             expect(dateTime.endsWith(dateString.at(-1))).toBe(true);
+        });
+
+        it('should be correctly asserted using expect.toMatchObject', () => {
+            const dateTime = DateTime.now().set({year: 2001});
+            const dateString = dateTime.toJSON();
+            expect({dateTime, dateString}).toMatchObject({
+                dateTime: dateTime.clone(),
+                dateString,
+            });
         });
     });
 });

--- a/__tests__/plugins/sequelize.test.js
+++ b/__tests__/plugins/sequelize.test.js
@@ -222,7 +222,7 @@ describe('Date sequelize utils', () => {
             {
                 label,
                 expiredAt: toDateOnly('2023-07-19'),
-                storedAt: toDateTime('2022-11-29'),
+                storedAt: toDateTime('2022-11-29T00:30:44.000-10:00'),
             },
             {
                 label,

--- a/date-only.cjs
+++ b/date-only.cjs
@@ -788,19 +788,9 @@ class DateOnly {
         return `DateOnly(${this.toJSON()})`;
     }
 
-    // MomentJs/Sequelize Compatibility layer
-    get [Symbol.toStringTag]() {
-        return 'Date';
-    }
-
     // For better debugging
     [Symbol.for('nodejs.util.inspect.custom')]() {
         return this.debug();
-    }
-
-    /** @deprecated This method is for compatibility only, prefer to use `toTimestamp` instead */
-    getTime() {
-        return this.toTimestamp();
     }
 
     /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */

--- a/date-only.mjs
+++ b/date-only.mjs
@@ -797,19 +797,9 @@ export class DateOnly {
         return `DateOnly(${this.toJSON()})`;
     }
 
-    // MomentJs/Sequelize Compatibility layer
-    get [Symbol.toStringTag]() {
-        return 'Date';
-    }
-
     // For better debugging
     [Symbol.for('nodejs.util.inspect.custom')]() {
         return `DateOnly(${this.toJSON()})`;
-    }
-
-    /** @deprecated This method is for compatibility only, prefer to use `toTimestamp` instead */
-    getTime() {
-        return this.toTimestamp();
     }
 
     /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -254,6 +254,7 @@ class DateTime {
      * Construct a new date-time from a moment object value
      * @param {Moment} date any moment date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromMomentDate(date, locale) {
         return new DateTime(date, locale);
@@ -263,6 +264,7 @@ class DateTime {
      * Construct a new date-time from a plain js Date
      * @param {Date} date any plain js Date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromJsDate(date, locale) {
         return new DateTime(moment(date), locale);
@@ -272,6 +274,7 @@ class DateTime {
      * Construct a new date-time from a DateTime isntance
      * @param {DateTime} dateTime any date-time object
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromDateTime(dateTime, locale) {
         if (dateTime instanceof DateTime) {
@@ -305,6 +308,7 @@ class DateTime {
      * Construct a new date-time from a DateOnly isntance
      * @param {DateOnly} dateOnly any date-only object
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromDateOnly(dateOnly, locale) {
         if (__isDateOnly(dateOnly)) {
@@ -325,6 +329,7 @@ class DateTime {
      * Construct a new date-time from any valid date value
      * @param {AnyDate} dateOnly any valid date. Empty (null or undefined) or NaN will return an invalid date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromAnyDate(anyDate, locale) {
         if (!anyDate) return this.invalid();
@@ -344,6 +349,7 @@ class DateTime {
      * @param {string} dateString any valid date string
      * @param {string} format the `dateString` parsing format
      * @param {string} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromFormat(dateString, format, locale) {
         let momentDate = moment(dateString, format, true);
@@ -840,19 +846,9 @@ class DateTime {
         return `DateTime(${this.toISOString(false).replace('T', ' ')})`;
     }
 
-    // MomentJs/Sequelize Compatibility layer
-    get [Symbol.toStringTag]() {
-        return 'Date';
-    }
-
     // For better debugging
     [Symbol.for('nodejs.util.inspect.custom')]() {
         return this.debug();
-    }
-
-    /** @deprecated This method is for compatibility only, prefer to use `toTimestamp` instead */
-    getTime() {
-        return this.toTimestamp();
     }
 
     /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */

--- a/date-time.mjs
+++ b/date-time.mjs
@@ -840,19 +840,9 @@ export class DateTime {
         return `DateTime(${this.toISOString(false).replace('T', ' ')})`;
     }
 
-    // MomentJs/Sequelize Compatibility layer
-    get [Symbol.toStringTag]() {
-        return 'Date';
-    }
-
     // For better debugging
     [Symbol.for('nodejs.util.inspect.custom')]() {
         return this.debug();
-    }
-
-    /** @deprecated This method is for compatibility only, prefer to use `toTimestamp` instead */
-    getTime() {
-        return this.toTimestamp();
     }
 
     /** @deprecated Some sequelzie versions look for this method instead of relying on MomentJs */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",

--- a/plugins/sequelize.cjs
+++ b/plugins/sequelize.cjs
@@ -1,8 +1,57 @@
-const {DataTypes} = require('sequelize');
+const {DataTypes, Utils} = require('sequelize');
 const {SequelizeMethod} = require('sequelize/lib/utils');
 
 const {DateOnly} = require('../date-only.cjs');
 const {DateTime} = require('../date-time.cjs');
+
+class DateOnlyDataType extends DataTypes.ABSTRACT.prototype.constructor {
+    static get key() {
+        return 'VINTAGE_DATETIME'
+    }
+
+    constructor(...args) {
+        super(...args);
+    }
+
+    toSql() {
+        return 'DATE';
+    }
+
+    _stringify(date) {
+        return DateOnly.fromAnyDate(date).toJSON();
+    }
+
+    stringify(date) {
+        return this._stringify(date);
+    }
+}
+
+class DateTimeDataType extends DataTypes.ABSTRACT.prototype.constructor {
+    static get key() {
+        return 'VINTAGE_DATETIME'
+    }
+
+    constructor(...args) {
+        super(...args);
+    }
+
+    toSql() {
+        return 'DATETIME';
+    }
+
+    _stringify(date) {
+        return DateTime.fromAnyDate(date).toJSON().replace(/Z$/, '+00:00');
+    }
+
+    stringify(date) {
+        return this._stringify(date);
+    }
+}
+
+DataTypes.VINTAGE_DATEONLY = Utils.classToInvokable(DateOnlyDataType);
+DataTypes.VINTAGE_DATEONLY.prototype.key = DataTypes.VINTAGE_DATEONLY.key;
+DataTypes.VINTAGE_DATETIME = Utils.classToInvokable(DateTimeDataType);
+DataTypes.VINTAGE_DATETIME.prototype.key = DataTypes.VINTAGE_DATETIME.key;
 
 /** @returns {value is SequelizeMethod} */
 function isSequelizeMethod(value) {
@@ -51,7 +100,7 @@ function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
  */
 function dateOnlyColumn(propertyName, strict = false) {
     return {
-        type: DataTypes.DATEONLY,
+        type: DateOnlyDataType,
         ...dateOnlyColumnGetterSetter(propertyName, strict),
     };
 }
@@ -96,9 +145,9 @@ function dateTimeColumnGetterSetter(propertyName, throwOnIncompatibleType) {
  */
 function dateTimeColumn(propertyName, strict = false) {
     return {
-        type: DataTypes.DATE,
+        type: DateTimeDataType,
         ...dateTimeColumnGetterSetter(propertyName, strict),
     };
 }
 
-module.exports = {dateOnlyColumn, dateTimeColumn};
+module.exports = {dateOnlyColumn, dateTimeColumn, DateOnlyDataType, DateTimeDataType};

--- a/plugins/sequelize.d.mts
+++ b/plugins/sequelize.d.mts
@@ -2,6 +2,22 @@ import {DataTypes} from 'sequelize';
 
 import {DateTime, DateOnly} from '../index.mts';
 
+export class DateOnlyDataType extends DataTypes.ABSTRACT {
+    static readonly key: 'VINTAGE_DATEONLY';
+
+    toSql(): string;
+
+    stringify(date): string;
+}
+
+export class DateTimeDataType extends DataTypes.ABSTRACT {
+    static readonly key: 'VINTAGE_DATETIME';
+
+    toSql(): string;
+
+    stringify(date): string;
+}
+
 /**
  * Get sequelize DATEONLY type properties
  * It includes getter and setter since DATEONLY in sequelize only accepts javascript Date objects but returns string on fetch
@@ -28,10 +44,10 @@ import {DateTime, DateOnly} from '../index.mts';
  * ````
  */
 export function dateOnlyColumn(propertyName: string, strict?: boolean): {
-    type: typeof DataTypes.DATEONLY,
+    type: DateOnlyDataType,
     get(): DateOnly | null;
     set(value: any): void;
-}
+};
 
 /**
  * Get sequelize DATETIME type properties
@@ -58,7 +74,7 @@ export function dateOnlyColumn(propertyName: string, strict?: boolean): {
  * ````
  */
 export function dateTimeColumn(propertyName: string, strict?: boolean): {
-    type: typeof DataTypes.DATE,
+    type: DateTimeDataType,
     get(): DateTime | null;
     set(value: any): void;
 };

--- a/plugins/sequelize.d.ts
+++ b/plugins/sequelize.d.ts
@@ -2,6 +2,22 @@ import {DataTypes} from 'sequelize';
 
 import {DateTime, DateOnly} from '../index.cts';
 
+export class DateOnlyDataType extends DataTypes.ABSTRACT {
+    static readonly key: 'VINTAGE_DATEONLY';
+
+    toSql(): string;
+
+    stringify(date): string;
+}
+
+export class DateTimeDataType extends DataTypes.ABSTRACT {
+    static readonly key: 'VINTAGE_DATETIME';
+
+    toSql(): string;
+
+    stringify(date): string;
+}
+
 /**
  * Get sequelize DATEONLY type properties
  * It includes getter and setter since DATEONLY in sequelize only accepts javascript Date objects but returns string on fetch
@@ -28,10 +44,10 @@ import {DateTime, DateOnly} from '../index.cts';
  * ````
  */
 export function dateOnlyColumn(propertyName: string, strict?: boolean): {
-    type: typeof DataTypes.DATEONLY,
+    type: DateOnlyDataType,
     get(): DateOnly | null;
     set(value: any): void;
-}
+};
 
 /**
  * Get sequelize DATETIME type properties
@@ -58,7 +74,7 @@ export function dateOnlyColumn(propertyName: string, strict?: boolean): {
  * ````
  */
 export function dateTimeColumn(propertyName: string, strict?: boolean): {
-    type: typeof DataTypes.DATE,
+    type: DateTimeDataType,
     get(): DateTime | null;
     set(value: any): void;
 };

--- a/plugins/sequelize.mjs
+++ b/plugins/sequelize.mjs
@@ -1,8 +1,57 @@
-import {DataTypes} from 'sequelize';
+import {DataTypes, Utils} from 'sequelize';
 import {SequelizeMethod} from 'sequelize/lib/utils';
 
 import {DateOnly} from '../date-only.mjs';
 import {DateTime} from '../date-time.mjs';
+
+export class DateOnlyDataType extends DataTypes.ABSTRACT.prototype.constructor {
+    static get key() {
+        return 'VINTAGE_DATETIME'
+    }
+
+    constructor(...args) {
+        super(...args);
+    }
+
+    toSql() {
+        return 'DATE';
+    }
+
+    _stringify(date) {
+        return DateOnly.fromAnyDate(date).toJSON();
+    }
+
+    stringify(date) {
+        return this._stringify(date);
+    }
+}
+
+export class DateTimeDataType extends DataTypes.ABSTRACT.prototype.constructor {
+    static get key() {
+        return 'VINTAGE_DATETIME'
+    }
+
+    constructor(...args) {
+        super(...args);
+    }
+
+    toSql() {
+        return 'DATETIME';
+    }
+
+    _stringify(date) {
+        return DateTime.fromAnyDate(date).toJSON().replace(/Z$/, '+00:00');
+    }
+
+    stringify(date) {
+        return this._stringify(date);
+    }
+}
+
+DataTypes.VINTAGE_DATEONLY = Utils.classToInvokable(DateOnlyDataType);
+DataTypes.VINTAGE_DATEONLY.prototype.key = DataTypes.VINTAGE_DATEONLY.key;
+DataTypes.VINTAGE_DATETIME = Utils.classToInvokable(DateTimeDataType);
+DataTypes.VINTAGE_DATETIME.prototype.key = DataTypes.VINTAGE_DATETIME.key;
 
 /** @returns {value is SequelizeMethod} */
 function isSequelizeMethod(value) {
@@ -51,7 +100,7 @@ function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
  */
 export function dateOnlyColumn(propertyName, strict = false) {
     return {
-        type: DataTypes.DATEONLY,
+        type: DateOnlyDataType,
         ...dateOnlyColumnGetterSetter(propertyName, strict),
     };
 }
@@ -96,7 +145,7 @@ function dateTimeColumnGetterSetter(propertyName, throwOnIncompatibleType) {
  */
 export function dateTimeColumn(propertyName, strict = false) {
     return {
-        type: DataTypes.DATE,
+        type: DateTimeDataType,
         ...dateTimeColumnGetterSetter(propertyName, strict),
     };
 }

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/vintage-time.svg)](https://badge.fury.io/js/vintage-time)[![codecov](https://codecov.io/gh/fernando7jr/vintage-time/graph/badge.svg?token=OPIEI5SPCJ)](https://codecov.io/gh/fernando7jr/vintage-time)![example workflow](https://github.com/fernando7jr/vintage-time/actions/workflows/node.js.yml/badge.svg)[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
 
 
-DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates
+DateTime x DateOnly library with locale support. Compatible with sequelize, joi and plain javascript Dates
 
 Distributed through the [npm packge vintage-time](https://www.npmjs.com/vintage-time)
 


### PR DESCRIPTION
* Deprecated momentjs contructor support. Devs should manually cast to an object or string before constructing a momentjs date from either a DateOnly or DateTime object.
* Improved Sequelize zupport through custom types instead of relying on the momentjs constructor.
* Removed JS Date like methods `getTime` and `prototype.toString = () => 'Date'`. This was causing issues on jest