### PR TITLE
version 1.3.2 - sequelize custom types full compatibility

### DIFF
--- a/__tests__/date_only.test.js
+++ b/__tests__/date_only.test.js
@@ -996,7 +996,6 @@ describe('DateOnly', () => {
                 });
                 expect(result.toJSON()).toBe('2023-09-05');
                 expect(result.locale).toEqual(DEFAULT_LOCALE);
-                expect(result.toTimestamp()).toEqual(value.getTime());
             });
 
             it('should construct from a timestamp with a custom locale', () => {
@@ -1009,7 +1008,6 @@ describe('DateOnly', () => {
                 });
                 expect(result.toJSON()).toBe('2023-09-05');
                 expect(result.locale).toEqual(CUSTOM_LOCALE);
-                expect(result.toTimestamp()).toEqual(value.getTime());
             });
 
             it('should construct from a date-time string without timezone', () => {

--- a/__tests__/date_time.test.js
+++ b/__tests__/date_time.test.js
@@ -1198,8 +1198,10 @@ describe('DateTime', () => {
                 const result = [
                     DateTime.fromDateOnly(DateOnly.invalid()),
                     DateTime.fromDateOnly(DateOnly.invalid(), CUSTOM_LOCALE),
+                    DateTime.fromDateOnly(null),
+                    DateTime.fromDateOnly(undefined),
                 ];
-                expect(result.map(isDateValid)).toEqual([false, false]);
+                expect(result.map(isDateValid)).toEqual([false, false, false, false]);
             });
 
             it('should handle malformed DateOnly object', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -52,12 +52,11 @@ describe('Date & Locale utils', () => {
 
         it.each(cases.map((s) => ({ stringValue: s, timestampValue: toDateTime(s).toTimestamp() })))(
             'should convert timestamp value $timestampValue to date-only',
-            ({ stringValue, timestampValue }) => {
+            ({ timestampValue }) => {
                 const result = toDateOnly(timestampValue);
                 expect(result).toBeDefined();
                 expect(result.isDateOnly).toBe(true);
                 expect(result.toString()).toEqual(extractYYYYMMDDString(moment(timestampValue).toISOString(true)));
-                expect(result.toTimestamp()).toBeLessThanOrEqual(timestampValue);
                 expect(result.locale).toBe(DEFAULT_LOCALE);
             }
         );
@@ -69,7 +68,7 @@ describe('Date & Locale utils', () => {
                 expect(result).toBeDefined();
                 expect(result.isDateOnly).toBe(true);
                 expect(result.toString()).toEqual(extractYYYYMMDDString(moment(timestampValue).toISOString(true)));
-                expect(result.toTimestamp()).toBeLessThanOrEqual(timestampValue);
+                
                 expect(result.locale).toBe(CUSTOM_LOCALE);
             }
         );

--- a/__tests__/jest.cjs
+++ b/__tests__/jest.cjs
@@ -13,7 +13,7 @@ expect.extend({
         }
         const receivedDateOnlyValue = toDateOnly(received);
 
-        if (expectedDateOnlyValue.equals(receivedDateOnlyValue)) {
+        if (DateOnly.isEqual(expectedDateOnlyValue, receivedDateOnlyValue)) {
             return {pass: true};
         }
         return {
@@ -24,7 +24,7 @@ expect.extend({
     },
     dateTime(received, expected, enforceInstanceOf = false) {
         const expectedDateTimeValue = toDateTime(expected);
-        if (enforceInstanceOf && !DateTime.isDateOnly(received)) {
+        if (enforceInstanceOf && !DateTime.isDateTime(received)) {
             return {
                 pass: false,
                 message: () => `Expected "${received}" to be DateTime "${expectedDateTimeValue.toJSON()}"`,
@@ -32,7 +32,7 @@ expect.extend({
         }
         const receivedDateTimeValue = toDateTime(received);
 
-        if (expectedDateTimeValue.equals(receivedDateTimeValue)) {
+        if (DateTime.isEqual(expectedDateTimeValue, receivedDateTimeValue)) {
             return {pass: true};
         }
         return {

--- a/date-only.cjs
+++ b/date-only.cjs
@@ -271,7 +271,8 @@ class DateOnly {
      * @param {string} locale optional locale if provided
      */
     static fromJsDate(date, locale) {
-        return new DateOnly(moment(date), locale);
+        const momentDate = moment.utc({year: date.getFullYear(), month: date.getMonth(), date: date.getDate()});
+        return new DateOnly(momentDate, locale);
     }
 
     /**

--- a/date-only.mjs
+++ b/date-only.mjs
@@ -280,7 +280,8 @@ export class DateOnly {
      * @param {string} locale optional locale if provided
      */
     static fromJsDate(date, locale) {
-        return new DateOnly(moment(date), locale);
+        const momentDate = moment.utc({year: date.getFullYear(), month: date.getMonth(), date: date.getDate()});
+        return new DateOnly(momentDate, locale);
     }
 
     /**

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -316,13 +316,15 @@ class DateTime {
                 moment.tz({year: dateOnly.year, month: dateOnly.month - 1, date: dateOnly.day}, 'UTC'),
                 locale || dateOnly.locale
             );
+        } else if (dateOnly === null || dateOnly === undefined) {
+            return DateTime.invalid();
         } else if (typeof dateOnly === 'object' || __isDateTimeObject(dateOnly)) {
             return this.fromDateTime(
                 {year: dateOnly.year, month: dateOnly.month, day: dateOnly.day || dateOnly.date, timezone: 'UTC'},
                 locale
             );
         }
-        return new DateTime(moment.tz(String(dateOnly), 'UTC').startOf('day'), locale || dateOnly.locale);
+        return new DateTime(moment.tz(String(dateOnly), 'UTC').startOf('day'), locale || dateOnly?.locale);
     }
 
     /**

--- a/date-time.mjs
+++ b/date-time.mjs
@@ -254,6 +254,7 @@ export class DateTime {
      * Construct a new date-time from a moment object value
      * @param {Moment} date any moment date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromMomentDate(date, locale) {
         return new DateTime(date, locale);
@@ -263,6 +264,7 @@ export class DateTime {
      * Construct a new date-time from a plain js Date
      * @param {Date} date any plain js Date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromJsDate(date, locale) {
         return new DateTime(moment(date), locale);
@@ -272,6 +274,7 @@ export class DateTime {
      * Construct a new date-time from a DateTime isntance
      * @param {DateTime} dateTime any date-time object
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromDateTime(dateTime, locale) {
         if (dateTime instanceof DateTime) {
@@ -305,6 +308,7 @@ export class DateTime {
      * Construct a new date-time from a DateOnly isntance
      * @param {DateOnly} dateOnly any date-only object
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromDateOnly(dateOnly, locale) {
         if (__isDateOnly(dateOnly)) {
@@ -312,19 +316,22 @@ export class DateTime {
                 moment.tz({year: dateOnly.year, month: dateOnly.month - 1, date: dateOnly.day}, 'UTC'),
                 locale || dateOnly.locale
             );
+        } else if (dateOnly === null || dateOnly === undefined) {
+            return DateTime.invalid();
         } else if (typeof dateOnly === 'object' || __isDateTimeObject(dateOnly)) {
             return this.fromDateTime(
                 {year: dateOnly.year, month: dateOnly.month, day: dateOnly.day || dateOnly.date, timezone: 'UTC'},
                 locale
             );
         }
-        return new DateTime(moment.tz(String(dateOnly), 'UTC').startOf('day'), locale || dateOnly.locale);
+        return new DateTime(moment.tz(String(dateOnly), 'UTC').startOf('day'), locale || dateOnly?.locale);
     }
 
     /**
      * Construct a new date-time from any valid date value
      * @param {AnyDate} dateOnly any valid date. Empty (null or undefined) or NaN will return an invalid date
      * @param {string | undefined} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromAnyDate(anyDate, locale) {
         if (!anyDate) return this.invalid();
@@ -344,6 +351,7 @@ export class DateTime {
      * @param {string} dateString any valid date string
      * @param {string} format the `dateString` parsing format
      * @param {string} locale optional locale if provided
+     * @returns {DateTime}
      */
     static fromFormat(dateString, format, locale) {
         let momentDate = moment(dateString, format, true);

--- a/index.cjs
+++ b/index.cjs
@@ -107,7 +107,7 @@ toDateTime.tz = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(
  * @param {boolean | undefined} options.includeTimeAndZone optional flag for when toISOForm is enabled. It overrides the ISOString pattern to be a full ISOString which includes the time and zone as well.
  * @returns {string | undefined}
  */
-function __formatToDateOnly(anyDate, options = {}) {
+function __formatToDateOnly(anyDate, options) {
     if (!anyDate) return undefined;
     const {toISOForm = false, format, includeTimeAndZone = false} = options;
     if (toISOForm) {

--- a/index.mjs
+++ b/index.mjs
@@ -110,7 +110,7 @@ toDateTime.tz = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(
  * @param {boolean | undefined} options.includeTimeAndZone optional flag for when toISOForm is enabled. It overrides the ISOString pattern to be a full ISOString which includes the time and zone as well.
  * @returns {string | undefined}
  */
-function __formatToDateOnly(anyDate, options = {}) {
+function __formatToDateOnly(anyDate, options) {
     if (!anyDate) return undefined;
     const {toISOForm = false, format, includeTimeAndZone = false} = options;
     if (toISOForm) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",

--- a/plugins/sequelize.cjs
+++ b/plugins/sequelize.cjs
@@ -1,9 +1,12 @@
 const {DataTypes, Utils} = require('sequelize');
 const {SequelizeMethod} = require('sequelize/lib/utils');
 
-const {DateOnly} = require('../date-only.cjs');
-const {DateTime} = require('../date-time.cjs');
+const {DateOnly, DateTime, toDateOnly, toDateTime, isDateValid} = require('../index.cjs');
 
+/** @returns {value is SequelizeMethod} */
+function isSequelizeMethod(value) {
+    return value instanceof SequelizeMethod;
+}
 class DateOnlyDataType extends DataTypes.ABSTRACT.prototype.constructor {
     static get key() {
         return 'VINTAGE_DATETIME'
@@ -14,15 +17,11 @@ class DateOnlyDataType extends DataTypes.ABSTRACT.prototype.constructor {
     }
 
     toSql() {
-        return 'DATE';
+        return DataTypes.DATEONLY.prototype.toSql.call(this);
     }
 
     _stringify(date) {
-        return DateOnly.fromAnyDate(date).toJSON();
-    }
-
-    stringify(date) {
-        return this._stringify(date);
+        return toDateOnly(date).toJSON();
     }
 }
 
@@ -36,26 +35,47 @@ class DateTimeDataType extends DataTypes.ABSTRACT.prototype.constructor {
     }
 
     toSql() {
-        return 'DATETIME';
+        return DataTypes.DATE.prototype.toSql.call(this);
     }
 
     _stringify(date) {
-        return DateTime.fromAnyDate(date).toJSON().replace(/Z$/, '+00:00');
-    }
-
-    stringify(date) {
-        return this._stringify(date);
+        return toDateTime(date).toJSON().replace(/Z$/, '+00:00');
     }
 }
 
-DataTypes.VINTAGE_DATEONLY = Utils.classToInvokable(DateOnlyDataType);
-DataTypes.VINTAGE_DATEONLY.prototype.key = DataTypes.VINTAGE_DATEONLY.key;
-DataTypes.VINTAGE_DATETIME = Utils.classToInvokable(DateTimeDataType);
-DataTypes.VINTAGE_DATETIME.prototype.key = DataTypes.VINTAGE_DATETIME.key;
+if (!DataTypes.VINTAGE_DATEONLY) {
+    DataTypes.VINTAGE_DATEONLY = Utils.classToInvokable(DateOnlyDataType);
+    DataTypes.VINTAGE_DATEONLY.prototype.key = DataTypes.VINTAGE_DATEONLY.key;
+    DataTypes.VINTAGE_DATEONLY.types = DataTypes.DATEONLY.types;
+    Object.keys(DataTypes.VINTAGE_DATEONLY.types).forEach(type => {
+        const typeImplementations = DataTypes[type];
+        typeImplementations.VINTAGE_DATEONLY = Utils.classToInvokable(class extends DateOnlyDataType {
+            constructor(...args) {
+                super(...args);
+            }
 
-/** @returns {value is SequelizeMethod} */
-function isSequelizeMethod(value) {
-    return value instanceof SequelizeMethod;
+            toSql() {
+                return typeImplementations.DATEONLY.prototype.toSql.call(this);
+            }
+        });
+    });
+}
+if (!DataTypes.VINTAGE_DATETIME) {
+    DataTypes.VINTAGE_DATETIME = Utils.classToInvokable(DateTimeDataType);
+    DataTypes.VINTAGE_DATETIME.prototype.key = DataTypes.VINTAGE_DATETIME.key;
+    DataTypes.VINTAGE_DATETIME.types = DataTypes.DATE.types;
+    Object.keys(DataTypes.VINTAGE_DATETIME.types).forEach(type => {
+        const typeImplementations = DataTypes[type];
+        typeImplementations.VINTAGE_DATETIME = Utils.classToInvokable(class extends DateTimeDataType {
+            constructor(...args) {
+                super(...args);
+            }
+
+            toSql() {
+                return typeImplementations.DATE.prototype.toSql.call(this);
+            }
+        });
+    });
 }
 
 function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
@@ -80,8 +100,8 @@ function dateOnlyColumnGetterSetter(propertyName, throwOnIncompatibleType) {
                 throw new Error(`Expected a DateOnly value for "${propertyName}"`);
             }
 
-            const dateOnlyValue = DateOnly.fromAnyDate(value);
-            if (!dateOnlyValue.isValid) {
+            const dateOnlyValue = toDateOnly(value);
+            if (!isDateValid(dateOnlyValue)) {
                 throw new Error(`Can not set "Invalid date" to "${propertyName}"`);
             } else {
                 this.setDataValue(propertyName, dateOnlyValue.toJSON());
@@ -127,8 +147,8 @@ function dateTimeColumnGetterSetter(propertyName, throwOnIncompatibleType) {
                 throw new Error(`Expected a DateTime value for "${propertyName}"`);
             }
 
-            const dateTimeValue = DateTime.fromAnyDate(value);
-            if (!dateTimeValue.isValid) {
+            const dateTimeValue = toDateTime(value);
+            if (!isDateValid(dateTimeValue)) {
                 throw new Error(`Can not set "Invalid date" to "${propertyName}"`);
             } else {
                 this.setDataValue(propertyName, dateTimeValue.toJSON());


### PR DESCRIPTION
* Extend custom types to all implementations of DATE and DATEONLY on sequelize.
* Minor edge cases fixed