### PR TITLE
version 1.4.0: convertDurationToTimeUnit

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -10,6 +10,7 @@ const {
     formatToDateTime,
     formatToDateOnlyWithLocale,
     formatToDateTimeWithLocale,
+    convertDurationToTimeUnit,
     LOCALE_FORMATS,
     DateOnly,
     DateTime,
@@ -823,6 +824,12 @@ describe('Date & Locale utils', () => {
                 expect(error.message).toBe('Locale must be an string');
             }
         });
+
+        it('should use the format default options values', () => {
+            const stringValues = '2000-07-09T22:33:44.222+03:00';
+            const result = formatToDateOnlyWithLocale(stringValues)
+            expect(result).toBe('July 9, 2000')
+        });
     });
 
     describe('formatToDateTimeWithLocale', () => {
@@ -1048,6 +1055,31 @@ describe('Date & Locale utils', () => {
                 expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe('Locale must be an string');
             }
+        });
+
+        it('should use the format default options values', () => {
+            const stringValues = '2000-07-09T22:33:44.222+03:00';
+            const result = formatToDateTimeWithLocale(stringValues)
+            expect(result).toBe('July 9, 2000 10:33 PM')
+        });
+    });
+
+    describe('convertDurationToTimeUnit', () => {
+        it('should return NaN when the duration is invalid', () => {
+            const result = convertDurationToTimeUnit({years: NaN}, 'days');
+            expect(result).toBe(NaN);
+        });
+
+        it('should convert 1 year into months', () => {
+            const result = convertDurationToTimeUnit({years: 1}, 'months');
+            expect(result).toBe(12);
+        });
+
+        it('should convert 8 days into 1 week', () => {
+            let result = convertDurationToTimeUnit({days: 8}, 'weeks', false);
+            expect(result).toBe(1);
+            result = convertDurationToTimeUnit({days: 8}, 'weeks');
+            expect(result).toEqual(1.1428571428571428);
         });
     });
 });

--- a/index.cjs
+++ b/index.cjs
@@ -177,8 +177,8 @@ function formatToDateTime(anyDate) {
  * @returns {string | undefined}
  */
 function formatToDateOnlyWithLocale(anyDate, options) {
-    const {locale = true, format} = options || {};
-    return __formatToDateOnly(anyDate, {locale, format});
+    const {locale, format} = options || {};
+    return __formatToDateOnly(anyDate, {locale: locale || moment().locale(), format});
 }
 
 /**
@@ -191,7 +191,23 @@ function formatToDateOnlyWithLocale(anyDate, options) {
  */
 function formatToDateTimeWithLocale(anyDate, options) {
     const {locale, format} = options || {};
-    return __formatToDateTime(anyDate, {locale: locale || true, format});
+    return __formatToDateTime(anyDate, {locale: locale || moment().locale(), format});
+}
+
+/**
+ * Convert a duration input into an specific time unit.
+ * Returns `NaN` when the duration is invalid.
+ * @param {moment.FromTo | moment.DurationInputObject} durationInput any valid duration input
+ * @param {moment.unitOfTime.Base} toTimeUnit the time unit to have the duration converted into
+ * @param {boolean} precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
+ * @returns {number} the amount in the requested time unit. `NaN` when the duration is invalid.
+ */
+function convertDurationToTimeUnit(durationInput, toTimeUnit, precise = true) {
+    const duration = moment.duration(durationInput);
+    if (!duration.isValid()) return NaN;
+    const result = duration.as(toTimeUnit);
+    if (precise) return result;
+    return Math.floor(result);
 }
 
 module.exports = {
@@ -207,4 +223,5 @@ module.exports = {
     formatToDateTime,
     formatToDateOnlyWithLocale,
     formatToDateTimeWithLocale,
+    convertDurationToTimeUnit,
 };

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,4 +1,4 @@
-import type {Moment, unitOfTime} from 'moment-timezone';
+import {Moment, FromTo, DurationInputObject, unitOfTime} from 'moment-timezone';
 
 import {LOCALE_FORMATS} from './locale-formats.mts';
 export {LOCALE_FORMATS} from './locale-formats.mts';
@@ -1231,3 +1231,13 @@ export function formatToDateTimeWithLocale(anyDate: AnyDate, options?: {locale?:
  * @returns the formatted date string applying the locale or undefined
  */
 export function formatToDateTimeWithLocale(anyDate: AnyDate | null | undefined, options?: {locale?: string; format?: string}): string | undefined;
+
+/**
+ * Convert a duration input into an specific time unit.
+ * Returns `NaN` when the duration is invalid.
+ * @param durationInput any valid duration input
+ * @param toTimeUnit the time unit to have the duration converted into
+ * @param precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
+ * @returns the amount in the requested time unit. `NaN` when the duration is invalid.
+ */
+export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise = true): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type {Moment, unitOfTime} from 'moment-timezone';
+import {Moment, FromTo, DurationInputObject, unitOfTime} from 'moment-timezone';
 
 import {LOCALE_FORMATS} from './locale-formats.cts';
 export {LOCALE_FORMATS} from './locale-formats.cts';
@@ -1231,3 +1231,13 @@ export function formatToDateTimeWithLocale(anyDate: AnyDate, options?: {locale?:
  * @returns the formatted date string applying the locale or undefined
  */
 export function formatToDateTimeWithLocale(anyDate: AnyDate | null | undefined, options?: {locale?: string; format?: string}): string | undefined;
+
+/**
+ * Convert a duration input into an specific time unit.
+ * Returns `NaN` when the duration is invalid.
+ * @param durationInput any valid duration input
+ * @param toTimeUnit the time unit to have the duration converted into
+ * @param precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
+ * @returns the amount in the requested time unit. `NaN` when the duration is invalid.
+ */
+export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise = true): number;

--- a/index.mjs
+++ b/index.mjs
@@ -181,7 +181,7 @@ export function formatToDateTime(anyDate) {
  */
 export function formatToDateOnlyWithLocale(anyDate, options) {
     const {locale, format} = options || {};
-    return __formatToDateOnly(anyDate, {locale: locale || true, format});
+    return __formatToDateOnly(anyDate, {locale: locale || moment().locale(), format});
 }
 
 /**
@@ -194,5 +194,21 @@ export function formatToDateOnlyWithLocale(anyDate, options) {
  */
 export function formatToDateTimeWithLocale(anyDate, options) {
     const {locale, format} = options || {};
-    return __formatToDateTime(anyDate, {locale: locale || true, format});
+    return __formatToDateTime(anyDate, {locale: locale || moment().locale(), format});
+}
+
+/**
+ * Convert a duration input into an specific time unit.
+ * Returns `NaN` when the duration is invalid.
+ * @param {moment.FromTo | moment.DurationInputObject} durationInput any valid duration input
+ * @param {moment.unitOfTime.Base} toTimeUnit the time unit to have the duration converted into
+ * @param {boolean} precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
+ * @returns {number} the amount in the requested time unit. `NaN` when the duration is invalid.
+ */
+export function convertDurationToTimeUnit(durationInput, toTimeUnit, precise = true) {
+    const duration = moment.duration(durationInput);
+    if (!duration.isValid()) return NaN;
+    const result = duration.as(toTimeUnit);
+    if (precise) return result;
+    return Math.floor(result);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.3.5",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.3.5",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.3.5",
+    "version": "1.4.0",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",


### PR DESCRIPTION
* Added the new method convertDurationToTimeUnit
* Added missing tests scenarios to both formatToDateOnlyWithLocale and formatToDateTimeWithLocale