### PR TITLE
version 1.4.1: fix type declarition files

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1240,4 +1240,4 @@ export function formatToDateTimeWithLocale(anyDate: AnyDate | null | undefined, 
  * @param precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
  * @returns the amount in the requested time unit. `NaN` when the duration is invalid.
  */
-export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise = true): number;
+export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise?: boolean): number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1240,4 +1240,4 @@ export function formatToDateTimeWithLocale(anyDate: AnyDate | null | undefined, 
  * @param precise whether to return the precise result or round it to the nearest integer (`Math.floor` is used). Defaults to `true`
  * @returns the amount in the requested time unit. `NaN` when the duration is invalid.
  */
-export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise = true): number;
+export function convertDurationToTimeUnit(durationInput: FromTo | DurationInputObject, toTimeUnit: unitOfTime.Base, precise?: boolean): number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",


### PR DESCRIPTION
Removed `= true` from `convertDurationToTimeUnit` function prototype declaration