### PR TITLE
version 1.5.0:

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,8 @@
 const moment = require('moment-timezone');
 
 const {
+    getDefaultTimeZone,
+    setDefaultTimeZone,
     isDateValid,
     getDateLocale,
     toJsDate,
@@ -15,6 +17,7 @@ const {
     DateOnly,
     DateTime,
 } = require('../index.cjs');
+const {getLocalTimezone} = require('../utils/tz.cjs');
 
 const DEFAULT_LOCALE = moment().locale();
 const ENGLISH_US_LOCALE = 'en-US';
@@ -331,6 +334,30 @@ describe('Date & Locale utils', () => {
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T19:33:44.222Z');
+            expect(result.locale).toBe(CUSTOM_LOCALE);
+        });
+
+        it('should have a sub-method as', () => {
+            let result = toDateTime.as('2000-07-09T22:33:44.222-03:00', 'UTC');
+            expect(result).toBeDefined();
+            expect(result.isDateTime).toBe(true);
+            expect(result.toString()).toBe('2000-07-09T22:33:44.222Z');
+            expect(result.locale).toBe(DEFAULT_LOCALE);
+            result = toDateTime.as('2000-07-09T22:33:44.222Z', 'America/Sao_Paulo');
+            expect(result).toBeDefined();
+            expect(result.isDateTime).toBe(true);
+            expect(result.toISOString()).toBe('2000-07-09T22:33:44.222-03:00');
+            expect(result.locale).toBe(DEFAULT_LOCALE);
+
+            result = toDateTime.as('2000-07-09T22:33:44.222+03:00', 'UTC', CUSTOM_LOCALE);
+            expect(result).toBeDefined();
+            expect(result.isDateTime).toBe(true);
+            expect(result.toString()).toBe('2000-07-09T22:33:44.222Z');
+            expect(result.locale).toBe(CUSTOM_LOCALE);
+            result = toDateTime.as('2000-07-09T22:33:44.222Z', 'America/Sao_Paulo', CUSTOM_LOCALE);
+            expect(result).toBeDefined();
+            expect(result.isDateTime).toBe(true);
+            expect(result.toString()).toBe('2000-07-09T22:33:44.222-03:00');
             expect(result.locale).toBe(CUSTOM_LOCALE);
         });
     });
@@ -1061,6 +1088,43 @@ describe('Date & Locale utils', () => {
             const stringValues = '2000-07-09T22:33:44.222+03:00';
             const result = formatToDateTimeWithLocale(stringValues)
             expect(result).toBe('July 9, 2000 10:33 PM')
+        });
+    });
+
+    describe('getDefaultTimeZone and setDefaultTimeZone', () => {
+        afterEach(() => {
+            setDefaultTimeZone();
+        });
+
+        it('should get the default timezone', () => {
+            const result = getDefaultTimeZone();
+            expect(result).toBe(getLocalTimezone());
+        });
+
+        it('should change the default timezone', () => {
+            setDefaultTimeZone('America/Sao_Paulo');
+            let result = getDefaultTimeZone();
+            expect(result).toBe('America/Sao_Paulo');
+            setDefaultTimeZone();
+            result = getDefaultTimeZone();
+            expect(result).toBe(getLocalTimezone());
+        });
+
+        it('should use the default timezone for DateTime', () => {
+            const timezones = [
+                'America/Sao_Paulo',
+                'Asia/Tokyo',
+                'UTC',
+            ];
+            const result = timezones.map((tz) => {
+                setDefaultTimeZone(tz);
+                const dateTimeNow = toDateTime.now();
+                return dateTimeNow.timezone;
+            });
+            expect(result).toEqual(timezones);
+
+            setDefaultTimeZone(undefined);
+            expect(toDateTime.now().timezone).toEqual(getLocalTimezone());
         });
     });
 

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -617,10 +617,24 @@ class DateTime {
     /**
      * Move this DateTime to a different timezone. The new offset is applied.
      * @param {string} timezone the new timezone
+     * @param {boolean} keepLocalTime optional boolean for keeping the original date and time instead of shifting to the new offset. Defaults to `false`
      * @returns {DateTime} a new DateTime using the specified timezone
      */
-    toTimezone(timezone) {
-        return DateTime.fromMomentDate(moment.tz(this._timestamp, timezone), this._locale);
+    toTimezone(timezone, keepLocalTime = false) {
+        let momentDate = moment(this._timestamp).tz(timezone);
+        if (keepLocalTime) {
+            const thisMoment = _momentDate(this);
+            momentDate.set({
+                year: thisMoment.year(),
+                month: thisMoment.month(),
+                date: thisMoment.date(),
+                hours: thisMoment.hours(),
+                minutes: thisMoment.minutes(),
+                seconds: thisMoment.seconds(),
+                milliseconds: thisMoment.milliseconds(),
+            });
+        }
+        return DateTime.fromMomentDate(momentDate, this._locale);
     }
 
     /**

--- a/date-time.mjs
+++ b/date-time.mjs
@@ -617,10 +617,24 @@ export class DateTime {
     /**
      * Move this DateTime to a different timezone. The new offset is applied.
      * @param {string} timezone the new timezone
+     * @param {boolean} keepLocalTime optional boolean for keeping the original date and time instead of shifting to the new offset. Defaults to `false`
      * @returns {DateTime} a new DateTime using the specified timezone
      */
-    toTimezone(timezone) {
-        return DateTime.fromMomentDate(moment.tz(this._timestamp, timezone), this._locale);
+    toTimezone(timezone, keepLocalTime = false) {
+        let momentDate = moment(this._timestamp).tz(timezone);
+        if (keepLocalTime) {
+            const thisMoment = _momentDate(this);
+            momentDate.set({
+                year: thisMoment.year(),
+                month: thisMoment.month(),
+                date: thisMoment.date(),
+                hours: thisMoment.hours(),
+                minutes: thisMoment.minutes(),
+                seconds: thisMoment.seconds(),
+                milliseconds: thisMoment.milliseconds(),
+            });
+        }
+        return DateTime.fromMomentDate(momentDate, this._locale);
     }
 
     /**

--- a/index.cjs
+++ b/index.cjs
@@ -3,9 +3,26 @@ const moment = require('moment-timezone');
 const {DateOnly} = require('./date-only.cjs');
 const {DateTime} = require('./date-time.cjs');
 const {LOCALE_FORMATS} = require('./locale-formats.cjs');
+const {getLocalTimezone} = require('./utils/tz.cjs');
 
 /** @typedef {Date | import('moment-timezone').Moment | DateOnly | DateTime | string | number} AnyDate */
 /** @typedef {{locale?: string | boolean; toISOForm?: boolean; format?: string}} DateFormatingOptions */
+
+/**
+ * Get the default timezone.
+ * @returns {string} the default timezone name
+ */
+function getDefaultTimeZone() {
+    return moment().tz() || getLocalTimezone();
+}
+
+/**
+ * Set the default timezone to be used instead of the local timezone.
+ * @param {string | undefined} timezone the timezone to be set as the default one. `undefined` resets it to the local timezone.
+ */
+function setDefaultTimeZone(timezone) {
+    moment.tz.setDefault(timezone ?? undefined);
+}
 
 /**
  * Extract the locale from a date value.
@@ -96,6 +113,16 @@ toDateTime.now = (locale) => DateTime.now(locale);
  * @returns {DateTime | undefined}
  */
 toDateTime.tz = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(tz);
+/**
+ * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+ * `null` or `undefined` values will return `undefined` instead.
+ * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+ * @param {AnyDate | null | undefined} anyDate any possible date
+ * @param {string} tz the timezone for the date
+ * @param {string} locale optional locale if provided
+ * @returns {DateTime | undefined}
+ */
+toDateTime.as = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(tz, true);
 
 /**
  * Format a date to a date-only format
@@ -213,6 +240,8 @@ function convertDurationToTimeUnit(durationInput, toTimeUnit, precise = true) {
 module.exports = {
     DateOnly,
     DateTime,
+    getDefaultTimeZone,
+    setDefaultTimeZone,
     isDateValid,
     getDateLocale,
     LOCALE_FORMATS,

--- a/index.d.mts
+++ b/index.d.mts
@@ -860,9 +860,10 @@ export class DateTime {
     /**
      * Move this DateTime to a different timezone. The new offset is applied.
      * @param timezone the new timezone
+     * @param keepLocalTime optional boolean for keeping the original date and time instead of shifting to the new offset. Defaults to `false`
      * @returns a new DateTime using the specified timezone
      */
-    toTimezone(timezone: string): DateTime;
+    toTimezone(timezone: string, keepLocalTime?: boolean): DateTime;
 
     /**
      * Same as calling `toTimezone('UTC')`
@@ -1058,6 +1059,18 @@ export class DateTime {
 export type DateFormatingOptions = {locale?: string | boolean; toISOForm?: boolean; format?: string};
 
 /**
+ * Get the default timezone.
+ * @returns the default timezone name
+ */
+export function getDefaultTimeZone(): string;
+
+/**
+ * Set the default timezone to be used instead of the local timezone.
+ * @param timezone the timezone to be set as the default one. `undefined` resets it to the local timezone.
+ */
+export function setDefaultTimeZone(timezone?: string): void;
+
+/**
  * Extract the locale from a date value.
  * Please notice that only Moment, DateOnly and DateTime classes actually store a locale.
  * Other libraries might do so but need to be handled in this code too.
@@ -1161,6 +1174,27 @@ export interface ToDateTime {
      * @returns a new date-time at the specific timezone or undefined
      */
     tz(anyDate: AnyDate | null | undefined, tz: string, locale?: string): DateTime | undefined;
+
+    /**
+     * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+     * `null` or `undefined` values will return `undefined` instead.
+     * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+     * @param anyDate any possible date
+     * @param tz the timezone for the date
+     * @param locale optional locale if provided
+     * @returns a new date-time at the specific timezone
+     */
+    as(anyDate: AnyDate, tz: string, locale?: string): DateTime;
+    /**
+     * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+     * `null` or `undefined` values will return `undefined` instead.
+     * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+     * @param anyDate any possible date
+     * @param tz the timezone for the date
+     * @param locale optional locale if provided
+     * @returns a new date-time at the specific timezone or undefined
+     */
+    as(anyDate: AnyDate | null | undefined, tz: string, locale?: string): DateTime | undefined;
 }
 export const toDateTime: ToDateTime;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -860,9 +860,10 @@ export class DateTime {
     /**
      * Move this DateTime to a different timezone. The new offset is applied.
      * @param timezone the new timezone
+     * @param keepLocalTime optional boolean for keeping the original date and time instead of shifting to the new offset. Defaults to `false`
      * @returns a new DateTime using the specified timezone
      */
-    toTimezone(timezone: string): DateTime;
+    toTimezone(timezone: string, keepLocalTime?: boolean): DateTime;
 
     /**
      * Same as calling `toTimezone('UTC')`
@@ -1058,6 +1059,18 @@ export class DateTime {
 export type DateFormatingOptions = {locale?: string | boolean; toISOForm?: boolean; format?: string};
 
 /**
+ * Get the default timezone.
+ * @returns the default timezone name
+ */
+export function getDefaultTimeZone(): string;
+
+/**
+ * Set the default timezone to be used instead of the local timezone.
+ * @param timezone the timezone to be set as the default one. `undefined` resets it to the local timezone.
+ */
+export function setDefaultTimeZone(timezone?: string): void;
+
+/**
  * Extract the locale from a date value.
  * Please notice that only Moment, DateOnly and DateTime classes actually store a locale.
  * Other libraries might do so but need to be handled in this code too.
@@ -1161,6 +1174,27 @@ export interface ToDateTime {
      * @returns a new date-time at the specific timezone or undefined
      */
     tz(anyDate: AnyDate | null | undefined, tz: string, locale?: string): DateTime | undefined;
+
+    /**
+     * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+     * `null` or `undefined` values will return `undefined` instead.
+     * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+     * @param anyDate any possible date
+     * @param tz the timezone for the date
+     * @param locale optional locale if provided
+     * @returns a new date-time at the specific timezone
+     */
+    as(anyDate: AnyDate, tz: string, locale?: string): DateTime;
+    /**
+     * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+     * `null` or `undefined` values will return `undefined` instead.
+     * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+     * @param anyDate any possible date
+     * @param tz the timezone for the date
+     * @param locale optional locale if provided
+     * @returns a new date-time at the specific timezone or undefined
+     */
+    as(anyDate: AnyDate | null | undefined, tz: string, locale?: string): DateTime | undefined;
 }
 export const toDateTime: ToDateTime;
 

--- a/index.mjs
+++ b/index.mjs
@@ -2,6 +2,7 @@ import moment from 'moment-timezone';
 
 import {DateOnly} from './date-only.mjs';
 import {DateTime} from './date-time.mjs';
+import {getLocalTimezone} from './utils/tz.cjs';
 
 export {LOCALE_FORMATS} from './locale-formats.mjs';
 export {DateOnly} from './date-only.mjs';
@@ -9,6 +10,22 @@ export {DateTime} from './date-time.mjs';
 
 /** @typedef {Date | import('moment-timezone').Moment | DateOnly | DateTime | string | number} AnyDate */
 /** @typedef {{locale?: string | boolean; toISOForm?: boolean; format?: string}} DateFormatingOptions */
+
+/**
+ * Get the default timezone.
+ * @returns {string} the default timezone name
+ */
+export function getDefaultTimeZone() {
+    return moment().tz() || getLocalTimezone();
+}
+
+/**
+ * Set the default timezone to be used instead of the local timezone.
+ * @param {string | undefined} timezone the timezone to be set as the default one. `undefined` resets it to the local timezone.
+ */
+export function setDefaultTimeZone(timezone) {
+    moment.tz.setDefault(timezone ?? undefined);
+}
 
 /**
  * Extract the locale from a date value.
@@ -99,6 +116,16 @@ toDateTime.now = (locale) => DateTime.now(locale);
  * @returns {DateTime | undefined}
  */
 toDateTime.tz = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(tz);
+/**
+ * Convert a date value to DateTime object in a specific timezone but keeping the local time.
+ * `null` or `undefined` values will return `undefined` instead.
+ * Just a shortcut for `toDateTime(anyDate, locale).toTimezone(tz, true)`.
+ * @param {AnyDate | null | undefined} anyDate any possible date
+ * @param {string} tz the timezone for the date
+ * @param {string} locale optional locale if provided
+ * @returns {DateTime | undefined}
+ */
+toDateTime.as = (anyDate, tz, locale) => toDateTime(anyDate, locale).toTimezone(tz, true);
 
 /**
  * Format a date to a date-only format

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",


### PR DESCRIPTION
* Implemented getter/setter methods for the default timezone
* Added an method `as` to override the tz keeping the original time
* Changed the `toTimezone` implementation to handle the new feature added by `as` method