### PR TITLE
version 1.5.2: small fixes and improvements

### DIFF
--- a/__tests__/date_only.test.js
+++ b/__tests__/date_only.test.js
@@ -1264,9 +1264,13 @@ describe('DateOnly', () => {
                 expect(customLocaleValues.map((v) => v.locale)).toEqual(customLocaleValues.map(() => CUSTOM_LOCALE));
             });
 
-            it('should not be settable', () => {
+            it('should set locale', () => {
                 const dateOnly = toDateOnly.now();
                 dateOnly.locale = CUSTOM_LOCALE;
+                expect(dateOnly.locale).toEqual(CUSTOM_LOCALE);
+                dateOnly.locale = null;
+                expect(dateOnly.locale).toEqual(DEFAULT_LOCALE);
+                dateOnly.locale = undefined;
                 expect(dateOnly.locale).toEqual(DEFAULT_LOCALE);
             });
         });

--- a/__tests__/date_time.test.js
+++ b/__tests__/date_time.test.js
@@ -3,7 +3,7 @@ const moment = require('moment-timezone');
 const {DateOnly} = require('../date-only.cjs');
 const {DateTime} = require('../date-time.cjs');
 const {toDateOnly, toDateTime, isDateValid, formatToDateOnly} = require('../index.cjs');
-const {getLocalTimezone} = require('../utils/tz.cjs');
+const {getLocalTimezone} = require('../utils/local.cjs');
 
 const DEFAULT_LOCALE = moment().locale();
 const ENGLISH_LOCALE = 'en';
@@ -2019,9 +2019,13 @@ describe('DateTime', () => {
                 expect(customLocaleValues.map((v) => v.locale)).toEqual(customLocaleValues.map(() => CUSTOM_LOCALE));
             });
 
-            it('should not be settable', () => {
+            it('should set locale', () => {
                 const dateTime = toDateTime.now();
                 dateTime.locale = CUSTOM_LOCALE;
+                expect(dateTime.locale).toEqual(CUSTOM_LOCALE);
+                dateTime.locale = null;
+                expect(dateTime.locale).toEqual(DEFAULT_LOCALE);
+                dateTime.locale = undefined;
                 expect(dateTime.locale).toEqual(DEFAULT_LOCALE);
             });
         });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -17,7 +17,7 @@ const {
     DateOnly,
     DateTime,
 } = require('../index.cjs');
-const {getLocalTimezone} = require('../utils/tz.cjs');
+const {getLocalTimezone} = require('../utils/local.cjs');
 
 const DEFAULT_LOCALE = moment().locale();
 const ENGLISH_US_LOCALE = 'en-US';
@@ -329,36 +329,49 @@ describe('Date & Locale utils', () => {
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T19:33:44.222Z');
             expect(result.locale).toBe(DEFAULT_LOCALE);
+            expect(DateTime.isEqual(result, '2000-07-09T22:33:44.222+03:00')).toBe(true);
 
             result = toDateTime.tz('2000-07-09T22:33:44.222+03:00', 'UTC', CUSTOM_LOCALE);
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T19:33:44.222Z');
             expect(result.locale).toBe(CUSTOM_LOCALE);
+            expect(DateTime.isEqual(result, '2000-07-09T22:33:44.222+03:00')).toBe(true);
         });
 
         it('should have a sub-method as', () => {
-            let result = toDateTime.as('2000-07-09T22:33:44.222-03:00', 'UTC');
+            let dateString = '2000-07-09T22:33:44.222-03:00';
+            let result = toDateTime.as(dateString, 'UTC');
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T22:33:44.222Z');
             expect(result.locale).toBe(DEFAULT_LOCALE);
-            result = toDateTime.as('2000-07-09T22:33:44.222Z', 'America/Sao_Paulo');
+            expect(DateTime.isEqual(result, dateString)).toBe(false);
+
+            dateString = '2000-07-09T22:33:44.222Z';
+            result = toDateTime.as(dateString, 'America/Sao_Paulo');
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toISOString()).toBe('2000-07-09T22:33:44.222-03:00');
             expect(result.locale).toBe(DEFAULT_LOCALE);
+            expect(DateTime.isEqual(result, dateString)).toBe(false);
 
-            result = toDateTime.as('2000-07-09T22:33:44.222+03:00', 'UTC', CUSTOM_LOCALE);
+            // Using CUSTOM_LOCALE
+            dateString = '2000-07-09T22:33:44.222+03:00';
+            result = toDateTime.as(dateString, 'UTC', CUSTOM_LOCALE);
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T22:33:44.222Z');
             expect(result.locale).toBe(CUSTOM_LOCALE);
-            result = toDateTime.as('2000-07-09T22:33:44.222Z', 'America/Sao_Paulo', CUSTOM_LOCALE);
+            expect(DateTime.isEqual(result, dateString)).toBe(false);
+
+            dateString = '2000-07-09T22:33:44.222Z';
+            result = toDateTime.as(dateString, 'America/Sao_Paulo', CUSTOM_LOCALE);
             expect(result).toBeDefined();
             expect(result.isDateTime).toBe(true);
             expect(result.toString()).toBe('2000-07-09T22:33:44.222-03:00');
             expect(result.locale).toBe(CUSTOM_LOCALE);
+            expect(DateTime.isEqual(result, dateString)).toBe(false);
         });
     });
 

--- a/date-only.cjs
+++ b/date-only.cjs
@@ -4,6 +4,7 @@ const {LOCALE_FORMATS} = require('./locale-formats.cjs');
 const {DATE_ONLY_REGEX} = require('./regex.cjs');
 const {__isDateTimeObject} = require('./utils/date-time.cjs');
 const {__isDateOnlyObject} = require('./utils/date-only.cjs');
+const {getLocalLocale} = require('./utils/local.cjs');
 
 /**
  * @typedef {moment.Moment} Moment
@@ -394,7 +395,7 @@ class DateOnly {
      * @private prefer to use any of the static methods instead
      */
     constructor(date, locale) {
-        this._locale = locale ?? moment().locale();
+        this._locale = locale || getLocalLocale();
         if (date instanceof DateOnly) {
             this._year = date._year;
             this._month = date._month;
@@ -414,6 +415,15 @@ class DateOnly {
      */
     get locale() {
         return this._locale;
+    }
+
+    /**
+     * The locale set to this date.
+     * `null` and `undefined` values are changed to the default locale
+     * @param {string | null} value
+     */
+    set locale(locale) {
+        this._locale = locale || getLocalLocale();
     }
 
     /**

--- a/date-only.mjs
+++ b/date-only.mjs
@@ -4,6 +4,7 @@ import {LOCALE_FORMATS} from './locale-formats.mjs';
 import {DATE_ONLY_REGEX} from './regex.mjs';
 import {__isDateTimeObject} from './utils/date-time.mjs';
 import {__isDateOnlyObject} from './utils/date-only.mjs';
+import {getLocalLocale} from './utils/local.mjs';
 
 /**
  * @typedef {moment.Moment} Moment
@@ -394,7 +395,7 @@ export class DateOnly {
      * @private prefer to use any of the static methods instead
      */
     constructor(date, locale) {
-        this._locale = locale ?? moment().locale();
+        this._locale = locale || getLocalLocale();
         if (date instanceof DateOnly) {
             this._year = date._year;
             this._month = date._month;
@@ -414,6 +415,15 @@ export class DateOnly {
      */
     get locale() {
         return this._locale;
+    }
+
+    /**
+     * The locale set to this date.
+     * `null` and `undefined` values are changed to the default locale
+     * @param {string | null} value
+     */
+    set locale(locale) {
+        this._locale = locale || getLocalLocale();
     }
 
     /**

--- a/date-time.cjs
+++ b/date-time.cjs
@@ -4,7 +4,7 @@ const {LOCALE_FORMATS} = require('./locale-formats.cjs');
 const {DATE_ONLY_REGEX, DATE_TIME_REGEX, TIME_WITHOUT_ZONE_REGEX, extractTimezoneOffset} = require('./regex.cjs');
 const {__isDateTimeObject} = require('./utils/date-time.cjs');
 const {__isDateOnlyObject} = require('./utils/date-only.cjs');
-const {getLocalTimezone} = require('./utils/tz.cjs');
+const {getLocalLocale, getLocalTimezone} = require('./utils/local.cjs');
 
 /**
  * @typedef {moment.Moment} Moment
@@ -402,7 +402,7 @@ class DateTime {
      * @param {string | undefined} locale optional locale if provided
      */
     constructor(date, locale) {
-        this._locale = locale ?? moment().locale();
+        this._locale = locale || getLocalLocale();
         if (date instanceof DateTime) {
             this._timestamp = date._timestamp;
             this._timezone = date._timezone;
@@ -424,6 +424,15 @@ class DateTime {
      */
     get locale() {
         return this._locale;
+    }
+
+    /**
+     * The locale set to this date.
+     * `null` and `undefined` values are changed to the default locale
+     * @param {string | null} value
+     */
+    set locale(locale) {
+        this._locale = locale || getLocalLocale();
     }
 
     get timezone() {

--- a/date-time.mjs
+++ b/date-time.mjs
@@ -4,7 +4,7 @@ import {LOCALE_FORMATS} from './locale-formats.mjs';
 import {DATE_ONLY_REGEX, DATE_TIME_REGEX, TIME_WITHOUT_ZONE_REGEX, extractTimezoneOffset} from './regex.mjs';
 import {__isDateTimeObject} from './utils/date-time.mjs';
 import {__isDateOnlyObject} from './utils/date-only.mjs';
-import {getLocalTimezone} from './utils/tz.cjs';
+import {getLocalLocale, getLocalTimezone} from './utils/local.mjs';
 
 /**
  * @typedef {moment.Moment} Moment
@@ -402,7 +402,7 @@ export class DateTime {
      * @param {string | undefined} locale optional locale if provided
      */
     constructor(date, locale) {
-        this._locale = locale ?? moment().locale();
+        this._locale = locale || getLocalLocale();
         if (date instanceof DateTime) {
             this._timestamp = date._timestamp;
             this._timezone = date._timezone;
@@ -424,6 +424,15 @@ export class DateTime {
      */
     get locale() {
         return this._locale;
+    }
+
+    /**
+     * The locale set to this date.
+     * `null` and `undefined` values are changed to the default locale
+     * @param {string | null} value
+     */
+    set locale(locale) {
+        this._locale = locale || getLocalLocale();
     }
 
     get timezone() {

--- a/index.cjs
+++ b/index.cjs
@@ -3,7 +3,7 @@ const moment = require('moment-timezone');
 const {DateOnly} = require('./date-only.cjs');
 const {DateTime} = require('./date-time.cjs');
 const {LOCALE_FORMATS} = require('./locale-formats.cjs');
-const {getLocalTimezone} = require('./utils/tz.cjs');
+const {getLocalTimezone} = require('./utils/local.cjs');
 
 /** @typedef {Date | import('moment-timezone').Moment | DateOnly | DateTime | string | number} AnyDate */
 /** @typedef {{locale?: string | boolean; toISOForm?: boolean; format?: string}} DateFormatingOptions */

--- a/index.d.mts
+++ b/index.d.mts
@@ -223,10 +223,18 @@ export class DateOnly {
     readonly isDateOnly: true;
 
     /**
-     * The locale set to this date
-     * Defaults to the global locale if none was provided
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
      */
-    readonly locale: string;
+    get locale(): string;
+
+    /**
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
+     * `null` and `undefined` values are changed to the default locale.
+     * @param value
+     */
+    set locale(value: string | undefined | null);
 
     /**
      * The year for this date.
@@ -708,10 +716,18 @@ export class DateTime {
     readonly isDateTime: true;
 
     /**
-     * The locale set to this date
-     * @returns the locale set to this date. Defaults to the global locale if none was provided
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
      */
-    readonly locale: string;
+    get locale(): string;
+
+    /**
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
+     * `null` and `undefined` values are changed to the default locale.
+     * @param value
+     */
+    set locale(value: string | undefined | null);
 
     readonly timezone: string | undefined;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -223,10 +223,18 @@ export class DateOnly {
     readonly isDateOnly: true;
 
     /**
-     * The locale set to this date
-     * Defaults to the global locale if none was provided
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
      */
-    readonly locale: string;
+    get locale(): string;
+
+    /**
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
+     * `null` and `undefined` values are changed to the default locale.
+     * @param value
+     */
+    set locale(value: string | undefined | null);
 
     /**
      * The year for this date.
@@ -708,10 +716,18 @@ export class DateTime {
     readonly isDateTime: true;
 
     /**
-     * The locale set to this date
-     * @returns the locale set to this date. Defaults to the global locale if none was provided
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
      */
-    readonly locale: string;
+    get locale(): string;
+
+    /**
+     * The locale set to this date.
+     * Defaults to the global locale if none was provided.
+     * `null` and `undefined` values are changed to the default locale.
+     * @param value
+     */
+    set locale(value: string | undefined | null);
 
     readonly timezone: string | undefined;
 

--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 
 import {DateOnly} from './date-only.mjs';
 import {DateTime} from './date-time.mjs';
-import {getLocalTimezone} from './utils/tz.cjs';
+import {getLocalTimezone} from './utils/local.mjs';
 
 export {LOCALE_FORMATS} from './locale-formats.mjs';
 export {DateOnly} from './date-only.mjs';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vintage-time",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vintage-time",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "license": "MIT",
             "dependencies": {
                 "moment-timezone": "^0.5.45"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vintage-time",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "DateTime x DateOnly library with locale support. Compatible with sequelize, joi, momentjs and plain javascript Dates",
     "type": "commonjs",
     "main": "index.cjs",

--- a/utils/local.cjs
+++ b/utils/local.cjs
@@ -1,3 +1,13 @@
+const moment = require('moment-timezone');
+
+/**
+ * Return the local timezone
+ * @returns {string}
+ */
+function getLocalLocale() {
+    return moment().locale();
+}
+
 /**
  * Return the local timezone
  * @returns {string}
@@ -7,5 +17,6 @@ function getLocalTimezone() {
 }
 
 module.exports = {
+    getLocalLocale,
     getLocalTimezone,
 };

--- a/utils/local.mjs
+++ b/utils/local.mjs
@@ -1,0 +1,17 @@
+import moment from 'moment-timezone';
+
+/**
+ * Return the local timezone
+ * @returns {string}
+ */
+export function getLocalLocale() {
+    return moment().locale();
+}
+
+/**
+ * Return the local timezone
+ * @returns {string}
+ */
+export function getLocalTimezone() {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}


### PR DESCRIPTION
* Changed locale to be settable
* Replaced `utils/tz` by `utils/local` which handle sboth local timezone and locale
* Added comparing, `tz` and `as` methods to Readme